### PR TITLE
T32: Added typeclasses for ThickMaze.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -33,3 +33,6 @@ target_link_libraries(sidewinder LINK_PUBLIC spelunker)
 
 add_executable(wilson wilson.cpp Executor.h Utils.h)
 target_link_libraries(wilson LINK_PUBLIC spelunker)
+
+add_executable(thicktest testthick.cpp)
+target_link_libraries(thicktest LINK_PUBLIC spelunker)

--- a/apps/testthick.cpp
+++ b/apps/testthick.cpp
@@ -1,0 +1,23 @@
+/**
+ * testthick.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <iostream>
+using namespace std;
+
+#include "DFSMazeGenerator.h"
+#include "ThickMaze.h"
+#include "Maze.h"
+#include "Homomorphism.h"
+#include "Show.h"
+
+int main(int argc, char *argv[]) {
+    spelunker::maze::DFSMazeGenerator dfs(20, 15);
+    spelunker::maze::Maze m = dfs.generate();
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m);
+
+    spelunker::thickmaze::ThickMaze tm = spelunker::typeclasses::Homomorphism<spelunker::maze::Maze, spelunker::thickmaze::ThickMaze>::morph(m);
+    std::cout << spelunker::typeclasses::Show<spelunker::thickmaze::ThickMaze>::show(tm);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PUBLIC_HEADER_FILES
         DFSMazeGenerator.h
         EllerMazeGenerator.h
         Exceptions.h
+        Homomorphism.h
         KruskalMazeGenerator.h
         Maze.h
         MazeAttributes.h
@@ -30,6 +31,10 @@ set(PUBLIC_HEADER_FILES
         SidewinderMazeGenerator.h
         SpelunkerConfig.h
         StringMazeRenderer.h
+        StringThickMazeRenderer.h
+        ThickMaze.h
+        ThickMazeAttributes.h
+        ThickMazeRenderer.h
         WilsonMazeGenerator.h
         )
 
@@ -51,6 +56,8 @@ set(SOURCE_FILES
         Show.h
         SidewinderMazeGenerator.cpp
         StringMazeRenderer.cpp
+        StringThickMazeRenderer.cpp
+        ThickMaze.cpp
         WilsonMazeGenerator.cpp
         )
 

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -25,6 +25,7 @@ namespace spelunker::shared {
     class OutOfBoundsCell : public Exception {
     public:
         OutOfBoundsCell(const spelunker::maze::types::Cell &c) : Exception(msg(c)) {}
+        OutOfBoundsCell(const int x, const int y) : OutOfBoundsCell(maze::types::cell(x, y)) {}
 
     private:
         static std::string msg(const spelunker::maze::types::Cell &c) {

--- a/src/Homomorphism.h
+++ b/src/Homomorphism.h
@@ -1,0 +1,23 @@
+/**
+ * Homomorphism.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#ifndef SPELUNKER_HOMOMORPHISM_H
+#define SPELUNKER_HOMOMORPHISM_H
+
+namespace spelunker::typeclasses {
+    /**
+     * A homomorphism is a structure-preserving map.
+     * This type class represents a map from one class to another.
+     */
+     template<typename S, typename T>
+     struct Homomorphism {
+         // std::T morph(S);
+         static constexpr bool is_instance = false;
+         using src = S;
+         using type = T;
+     };
+}
+#endif //SPELUNKER_HOMOMORPHISM_H

--- a/src/StringMazeRenderer.cpp
+++ b/src/StringMazeRenderer.cpp
@@ -15,9 +15,7 @@
 #include "MazeAttributes.h"
 
 namespace spelunker::maze {
-    using namespace std;
-
-    const vector<string> StringMazeRenderer::boxchars = { " ","╶","╷","┌","╴","─","┐","┬","╵","└","│","├","┘","┴","┤","┼" };
+    const std::vector<std::string> StringMazeRenderer::boxchars = { " ","╶","╷","┌","╴","─","┐","┬","╵","└","│","├","┘","┴","┤","┼" };
 
     StringMazeRenderer::StringMazeRenderer(std::ostream &o) : out(o) {}
 
@@ -43,20 +41,20 @@ namespace spelunker::maze {
          * 3. B(x,y,S) = M(x-1, y,   E) || M(  x,   y, W)
          * 4. B(x,y,E) = M(  x, y-1, S) || M(  x,   y, N)
          */
-        const auto w = m.getWidth();
-        const auto h = m.getHeight();
+        const auto width  = m.getWidth();
+        const auto height = m.getHeight();
 
         // Create the box representation of the maze.
-        using BoxEntry = vector<bool>;
-        using BoxColumn = vector<BoxEntry>;
-        using BoxRepresentation = vector<BoxColumn>;
+        using BoxEntry = std::vector<bool>;
+        using BoxColumn = std::vector<BoxEntry>;
+        using BoxRepresentation = std::vector<BoxColumn>;
 
         BoxEntry          bDir(4, false);
-        BoxColumn         bCol(h+1, bDir);
-        BoxRepresentation box(w+1, bCol);
+        BoxColumn         bCol(height+1, bDir);
+        BoxRepresentation box(width+1, bCol);
 
-        for (auto x=0; x <= w; ++x) {
-            for (auto y=0; y <= h; ++y) {
+        for (auto x=0; x <= width; ++x) {
+            for (auto y=0; y <= height; ++y) {
                 box[x][y][types::NORTH] = wall(m, x-1, y-1, types::EAST)  || wall(m,   x, y-1, types::WEST);
                 box[x][y][types::WEST]  = wall(m, x-1, y-1, types::SOUTH) || wall(m, x-1,   y, types::NORTH);
                 box[x][y][types::SOUTH] = wall(m, x-1,   y, types::EAST)  || wall(m,   x,   y, types::WEST);
@@ -65,8 +63,8 @@ namespace spelunker::maze {
         }
 
         // Now we are ready to render.
-        for (auto y=0; y <= h; ++y) {
-            for (auto x=0; x <= w; ++x) {
+        for (auto y=0; y <= height; ++y) {
+            for (auto x=0; x <= width; ++x) {
                 const auto n = box[x][y][types::NORTH] ? 1 : 0;
                 const auto w = box[x][y][types::WEST]  ? 1 : 0;
                 const auto s = box[x][y][types::SOUTH] ? 1 : 0;

--- a/src/StringMazeRenderer.h
+++ b/src/StringMazeRenderer.h
@@ -22,15 +22,15 @@ namespace spelunker::maze {
 
     /// A simple maze renderer to an ostream. We use this to define the Show type class for Maze.
     /**
-     * This class takes an x by y Maze and converts it to a string that displays the maze using unicode box
-     * characters. The final dimensions of the box output are (2x+1) by (y+1).
+     * This class takes a w by h Maze and converts it to a string that displays the maze using unicode box
+     * characters. The final dimensions of the box output are 2w+1 by h+1.
      */
     class StringMazeRenderer final : public MazeRenderer {
     public:
         StringMazeRenderer(std::ostream &o);
-        virtual ~StringMazeRenderer() = default;
+        ~StringMazeRenderer() = default;
 
-        virtual void render(const Maze &m) override;
+        void render(const Maze &m) override;
 
     private:
         std::ostream &out;

--- a/src/StringThickMazeRenderer.cpp
+++ b/src/StringThickMazeRenderer.cpp
@@ -1,0 +1,36 @@
+/**
+ * StringThickMazeRenderer.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <ostream>
+#include <string>
+
+#include "StringThickMazeRenderer.h"
+#include "ThickMaze.h"
+#include "ThickMazeAttributes.h"
+
+namespace spelunker::thickmaze {
+    StringThickMazeRenderer::StringThickMazeRenderer(std::ostream &o) : out(o) {}
+
+    void StringThickMazeRenderer::render(const spelunker::thickmaze::ThickMaze &tm) {
+        const int width  = tm.getWidth();
+        const int height = tm.getHeight();
+
+        // Draw the border, and then the contents.
+        // Hence, we iterate from -1 (the west and north border walls) to
+        // width / height (the east / south border walls).
+        for (auto y = -1; y <= height; ++y) {
+            for (auto x = -1; x <= width; ++x) {
+                if (x == -1 || x == width
+                    || y == -1 || y == height
+                    || tm.cell(x, y) == types::WALL)
+                    out << "██";
+                else out << "  ";
+
+            }
+            out << std::endl;
+        }
+    }
+}

--- a/src/StringThickMazeRenderer.h
+++ b/src/StringThickMazeRenderer.h
@@ -1,0 +1,34 @@
+/**
+ * StringThickMazeRenderer.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#ifndef SPELUNKER_STRINGTHICKMAZERENDERER_H
+#define SPELUNKER_STRINGTHICKMAZERENDERER_H
+
+#include <ostream>
+#include <string>
+
+#include "ThickMazeRenderer.h"
+
+namespace spelunker::thickmaze {
+
+    /// A simple maze renderer to an ostream. We use this to define the Show type class for ThickMaze.
+    /**
+     * This class takes an x by y ThickMaze and converts it to a string that displays the maze using
+     * unicode characters.
+     */
+    class StringThickMazeRenderer final : public ThickMazeRenderer {
+    public:
+        StringThickMazeRenderer(std::ostream &o);
+        ~StringThickMazeRenderer() = default;
+
+        void render(const ThickMaze &tm) override;
+
+    private:
+        std::ostream &out;
+    };
+}
+
+#endif //SPELUNKER_STRINGTHICKMAZERENDERER_H

--- a/src/ThickMaze.h
+++ b/src/ThickMaze.h
@@ -9,7 +9,12 @@
 #ifndef SPELUNKER_THICKMAZE_H
 #define SPELUNKER_THICKMAZE_H
 
+#include <sstream>
+#include <string>
+
+#include "Show.h"
 #include "ThickMazeAttributes.h"
+#include "StringThickMazeRenderer.h"
 
 namespace spelunker::thickmaze {
     /**
@@ -25,6 +30,7 @@ namespace spelunker::thickmaze {
      * is surjective, and thus Mazes and ThickMazes with this property are isomorphic.
      */
     class ThickMaze final {
+    public:
         /**
          * Create a ThickMaze with the given width, height, and contents.
          * This class is effectively immutable.
@@ -47,4 +53,15 @@ namespace spelunker::thickmaze {
     };
 }
 
+namespace spelunker::typeclasses {
+    template<>
+    struct Show<thickmaze::ThickMaze> {
+        static std::string show(const thickmaze::ThickMaze &tm) {
+            std::ostringstream out;
+            thickmaze::StringThickMazeRenderer r(out);
+            r.render(tm);
+            return out.str();
+        }
+    };
+}
 #endif //SPELUNKER_THICKMAZE_H

--- a/src/ThickMazeRenderer.h
+++ b/src/ThickMazeRenderer.h
@@ -1,0 +1,19 @@
+/**
+ * ThickMazeRenderer.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#ifndef SPELUNKER_THICKMAZERENDERER_H
+#define SPELUNKER_THICKMAZERENDERER_H
+
+namespace spelunker::thickmaze {
+    class ThickMaze;
+
+    class ThickMazeRenderer {
+    public:
+        virtual void render(const ThickMaze &m) = 0;
+    };
+}
+
+#endif //SPELUNKER_THICKMAZERENDERER_H


### PR DESCRIPTION
Added `StringThickMazeRenderer` to render `ThickMaze` instances, and then hooked up a `Show` typeclass to show instances of `ThickMaze` as strings.

Added the `Homomorphism` typeclass and an instance of it to convert `Maze` to `ThickMaze`.

Added a test binary, `testthick.cpp`, to put it all together, create a DFS `Maze`, and then morph it to a `ThickMaze` and show it.