### PR TITLE
T21: Added support to turn mazes into unicursal mazes.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -40,5 +40,8 @@ target_link_libraries(sidewinder LINK_PUBLIC spelunker)
 add_executable(wilson wilson.cpp Executor.h Utils.h)
 target_link_libraries(wilson LINK_PUBLIC spelunker)
 
-add_executable(thicktest testthick.cpp)
-target_link_libraries(thicktest LINK_PUBLIC spelunker)
+add_executable(test_thickify test_thickify.cpp)
+target_link_libraries(test_thickify LINK_PUBLIC spelunker)
+
+add_executable(test_unicursal test_unicursal.cpp)
+target_link_libraries(test_unicursal LINK_PUBLIC spelunker)

--- a/apps/test_thickify.cpp
+++ b/apps/test_thickify.cpp
@@ -1,5 +1,5 @@
 /**
- * testthick.cpp
+ * test_thickify.cpp
  *
  * By Sebastian Raaphorst, 2018.
  */

--- a/apps/test_unicursal.cpp
+++ b/apps/test_unicursal.cpp
@@ -1,0 +1,24 @@
+/**
+ * test_unicursal.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <iostream>
+using namespace std;
+
+#include "DFSMazeGenerator.h"
+#include "Maze.h"
+#include "Show.h"
+
+int main(int argc, char *argv[]) {
+    spelunker::maze::DFSMazeGenerator dfs(10, 8);
+    spelunker::maze::Maze m = dfs.generate();
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m);
+
+    spelunker::maze::Maze mu = m.makeUnicursal();
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(mu);
+
+    spelunker::maze::Maze mu2 = mu.makeUnicursal();
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(mu2);
+}

--- a/src/Maze.h
+++ b/src/Maze.h
@@ -110,6 +110,30 @@ namespace spelunker::maze {
         /// Apply a symmetry to this maze to get a new one.
         const Maze applySymmetry(types::Symmetry s) const;
 
+        /// Make a perfect maze into a 2w x 2h unicursal maze (aka labyrinth).
+        /**
+         * Make a perfect maze of dimension w x h into a unicursal maze (aka labyrinth) of
+         * dimension 2w x 2h.
+         *
+         * This is done by taking every call and splitting it into a 2 x 2 set of cells
+         * where we bisect the cell, but with dead ends, leave one cell open at the end
+         * of the dead end to allow traversal through and around it.
+         *
+         * Note: The entrance of the original maze, if it exists and is against a border, is
+         * used to determine the entrance point / exit point of this maze.
+         * Otherwise, this maze is just one huge loop.
+         *
+         * Note: Exit points of the original maze are ignored in the construction of this maze,
+         * as by the construction to "unicursalize" this maze, the entrance and exit must be
+         * next to one another.
+         *
+         * Idea for this algorithm inspired by:
+         * https://github.com/jamis/theseus/blob/eff25e2d02da00bb9515690b83008ec05e852317/lib/theseus/orthogonal_maze.rb#L108
+         * 
+         * @return a unicursal modification of this maze
+         */
+        const Maze makeUnicursal() const;
+
     private:
         /// A function that maps positions to wall ranks.
         /**


### PR DESCRIPTION
This change allows a `Maze` of width `w` and height `h` to produce a unicursal maze based on itself (by bisecting every passage and making dead ends into U-turns) of width `2w` and height `2h`.
<img width="839" alt="screen shot 2018-05-26 at 3 57 31 pm" src="https://user-images.githubusercontent.com/8795653/40579810-6a5bd0d4-60fe-11e8-9704-61949b839e20.png">
