### PR TITLE
T45: Added functionality to braid thick mazes.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(wilson LINK_PUBLIC spelunker)
 add_executable(test_braid test_braid.cpp)
 target_link_libraries(test_braid LINK_PUBLIC spelunker)
 
+add_executable(test_thickbraid test_thickbraid.cpp)
+target_link_libraries(test_thickbraid LINK_PUBLIC spelunker)
+
 add_executable(test_thickify test_thickify.cpp)
 target_link_libraries(test_thickify LINK_PUBLIC spelunker)
 

--- a/apps/test_braid.cpp
+++ b/apps/test_braid.cpp
@@ -2,6 +2,8 @@
  * test_braid.cpp
  *
  * By Sebastian Raaphorst, 2018.
+ *
+ * Test the braid function of a Maze.
  */
 
 #include <iostream>
@@ -12,7 +14,7 @@ using namespace std;
 #include "typeclasses/Show.h"
 
 int main(int argc, char *argv[]) {
-    spelunker::maze::DFSMazeGenerator gen(50, 40);
+    spelunker::maze::DFSMazeGenerator gen(40, 30);
     spelunker::maze::Maze m = gen.generate();
     std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m);
 

--- a/apps/test_thickbraid.cpp
+++ b/apps/test_thickbraid.cpp
@@ -1,0 +1,26 @@
+/**
+ * test_thickbraid.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include "maze/DFSMazeGenerator.h"
+#include "maze/Maze.h"
+#include "thickmaze/ThickMaze.h"
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
+
+using namespace spelunker;
+
+int main(int argc, char *argv[]) {
+    maze::DFSMazeGenerator gen(22, 16);
+    maze::Maze m = gen.generate();
+    std::cout << typeclasses::Show<maze::Maze>::show(m);
+
+    thickmaze::ThickMaze tm = typeclasses::Homomorphism<maze::Maze, thickmaze::ThickMaze>::morph(m);
+    std::cout << typeclasses::Show<thickmaze::ThickMaze>::show(tm);
+
+    spelunker::thickmaze::ThickMaze btm = tm.braid();
+    std::cout << typeclasses::Show<thickmaze::ThickMaze>::show(btm);
+    return 0;
+}

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -2,6 +2,7 @@
 # By Sebastian Raaphorst, 2018.
 
 set(_MATH_PUBLIC_HEADER_FILES
+        MathUtils.h
         RNG.h
         )
 
@@ -10,6 +11,7 @@ set(_MATH_PRIVATE_HEADER_FILES
         )
 
 set(_MATH_SOURCE_FILES
+        MathUtils.cpp
         RNG.cpp
         DefaultRNG.cpp
         )

--- a/src/math/MathUtils.cpp
+++ b/src/math/MathUtils.cpp
@@ -1,0 +1,16 @@
+/**
+ * MathUtils.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <stdexcept>
+
+#include "MathUtils.h"
+
+namespace spelunker::math {
+    void MathUtils::checkProbability(const double probability) {
+        if (probability < 0 || probability > 1)
+            throw std::invalid_argument("Probability " + std::to_string(probability) + " is not in [0,1].");
+    }
+}

--- a/src/math/MathUtils.h
+++ b/src/math/MathUtils.h
@@ -1,0 +1,31 @@
+/**
+ * MathUtils.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Utilities to simplify some mathematical functions and value handling.
+ */
+
+#ifndef SPELUNKER_MATHUTILS_H
+#define SPELUNKER_MATHUTILS_H
+
+namespace spelunker::math {
+    /**
+     * A class with purely static members to offer handy functions to do with mathematics.
+     */
+    class MathUtils final {
+    private:
+        MathUtils() = default;
+        ~MathUtils() = default;
+
+    public:
+        /**
+         * Check to see if a probability is in the valid range [1,0].
+         * @param probability the probability to check
+         * @throws std::invalid_argument if they are not.
+         */
+        static void checkProbability(double probability);
+    };
+}
+
+#endif //SPELUNKER_MATHUTILS_H

--- a/src/maze/Maze.h
+++ b/src/maze/Maze.h
@@ -145,7 +145,7 @@ namespace spelunker::maze {
          * This method takes the current maze, and begins by creating a list of all the dead ends.
          * The list is then shuffled, and one-by-one, the algorithm considers each dead end cell and does the following:
          * 1. Determine if it is still indeed a dead end cell, as one of its walls may have already been removed.
-         * 2. Use probability to determine if we apply braid to this cell.
+         * 2. Use probability to determine if we apply braiding to this cell.
          * 3. Amongst the three neighbouring cells sharing a wall with this cell, pick one of the neighbours that
          *    has the largest number of walls. Ties are broken randomly.
          * 4. Delete the wall between this cell and the selected neighbour.
@@ -153,10 +153,18 @@ namespace spelunker::maze {
          * The reason for step (3) is because this allows us to minimize wall reduction, attempting to possibly
          * fix two dead ends at the same time (this cell, and the neighbour cell).
          *
-         * @param probability the probability of fixing a given dead end.
-         * @return
+         * @param probability the probability of fixing a given dead end
+         * @return a new maze with walls removed to decrease the number of dead ends
          */
         const Maze braid(double probability = 1.0) const;
+
+        /// Find the dead ends for this maze.
+        /**
+         * Find a collection of all the dead ends for this maze.
+         * A cell is considered a "dead end" if it has exactly three walls.
+         * @return a collection of the dead end cells
+         */
+        const types::CellCollection findDeadEnds() const noexcept;
 
     private:
         /// Determine the number of walls a cell has for an instance of WallIncidence.

--- a/src/thickmaze/ThickMaze.cpp
+++ b/src/thickmaze/ThickMaze.cpp
@@ -4,6 +4,8 @@
  * By Sebastian Raaphorst, 2018.
  */
 
+#include "math/MathUtils.h"
+#include "math/RNG.h"
 #include "types/CommonMazeAttributes.h"
 #include "types/Exceptions.h"
 #include "ThickMaze.h"
@@ -21,11 +23,115 @@ namespace spelunker::thickmaze {
         return contents[x][y];
     }
 
+    int ThickMaze::numCellWalls(const types::Cell &c) const {
+        return numCellWallsInContents(c, contents);
+    }
+
     const ThickMaze ThickMaze::reverse() const {
         auto invContents = createEmptyThickCellContents(width, height);
         for (auto y=0; y < height; ++y)
             for (auto x=0; x < width; ++x)
                 invContents[x][y] = contents[x][y] == FLOOR ? WALL : FLOOR;
         return ThickMaze(width, height, invContents);
+    }
+
+    const ThickMaze ThickMaze::braid(double probability) const {
+        math::MathUtils::checkProbability(probability);
+
+        // Create a copy of the contents for this maze for the new maze.
+        CellContents newContents = contents;
+
+        // Find all the dead ends and store them, shuffle them, and process.
+        types::CellCollection deadends = findDeadEnds();
+        math::RNG::shuffle(deadends);
+
+        // Lambda function to determine if a cell is a dead end.
+        auto isDeadEnd = [&newContents, this](const int x, const int y) {
+            if (x < 0 || x >= width || y < 0 || y >= height || newContents[x][y] == WALL)
+                return false;
+            return numCellWalls(types::cell(x,y)) == 3;
+        };
+
+        // Lambda function to determine how many dead ends are around a wall.
+        // Returns -1 if the coordinates do not specify a valid wall.
+        auto deadEndCounter = [&newContents, isDeadEnd, this](const int x, const int y) {
+            if (x < 0 || x >= width || y < 0 || y >= width || newContents[x][y] != WALL)
+                return -1;
+
+            int numDeadEnds = 0;
+            if (isDeadEnd(x-1, y)) ++numDeadEnds;
+            if (isDeadEnd(x+1, y)) ++numDeadEnds;
+            if (isDeadEnd(x, y-1)) ++numDeadEnds;
+            if (isDeadEnd(x, y+1)) ++numDeadEnds;
+            return numDeadEnds;
+        };
+
+        for (auto c: deadends) {
+            // Check that the probability successds and that thus cell is still a dead end.
+            if (math::RNG::randomProbability() > probability || numCellWallsInContents(c, newContents) < 3) {
+                continue;
+            }
+            const auto [x,y] = c;
+
+            // Create a list of the cells around this cell that can be removed and that
+            // eliminate the largest number of other dead ends.
+            std::vector<types::Cell> candidates;
+            int maxDeadEnds = 0;
+
+            auto cellHandler = [&maxDeadEnds, &candidates, deadEndCounter](const int x, const int y) {
+                auto dw = deadEndCounter(x, y);
+                if (dw < maxDeadEnds)
+                    return;
+
+                if (dw > maxDeadEnds) {
+                    candidates.clear();
+                    maxDeadEnds = dw;
+                }
+                candidates.emplace_back(types::cell(x,y));
+            };
+
+            cellHandler(x-1, y);
+            cellHandler(x+1, y);
+            cellHandler(x, y-1);
+            cellHandler(x, y+1);
+
+            // Now pick a candidate and remove the wall.
+            const auto [ex, ey] = math::RNG::randomElement(candidates);
+            newContents[ex][ey] = FLOOR;
+        }
+
+        return ThickMaze(width, height, newContents);
+    }
+
+    const types::CellCollection ThickMaze::findDeadEnds() const noexcept {
+        types::CellCollection deadends;
+        for (auto y = 0; y < height; ++y) {
+            for (auto x = 0; x < width; ++x) {
+                const auto c = types::cell(x, y);
+                if (numCellWalls(c) == 3)
+                    deadends.emplace_back(c);
+            }
+        }
+        return deadends;
+    }
+
+    int ThickMaze::numCellWallsInContents(const types::Cell &c, const CellContents &cc) const {
+        checkCell(c);
+        const auto [x,y] = c;
+        auto numCellWalls = 0;
+
+        if (x == 0 || cc[x-1][y] == WALL)        ++numCellWalls;
+        if (x == width-1 || cc[x+1][y] == WALL)  ++numCellWalls;
+        if (y == 0 || cc[x][y-1] == WALL)        ++numCellWalls;
+        if (y == height-1 || cc[x][y+1] == WALL) ++numCellWalls;
+
+        return numCellWalls;
+    }
+
+
+    void ThickMaze::checkCell(const types::Cell &c) const {
+        const auto [x,y] = c;
+        if (x < 0 || x >= width || y < 0 || y >= height)
+            throw types::OutOfBoundsCell(types::Cell(x, y));
     }
 }

--- a/src/thickmaze/ThickMaze.h
+++ b/src/thickmaze/ThickMaze.h
@@ -46,6 +46,9 @@ namespace spelunker::thickmaze {
 
         const CellType cellIs(int x, int y) const;
 
+        /// Determine the number of walls a cell has.
+        int numCellWalls(const types::Cell &c) const;
+
         /**
          * This algorithm swaps walls and floors, not including the border wall. It is useful for some
          * cellular automata algorithms, which are sometimes more wall-connected than floor-connected.
@@ -53,7 +56,52 @@ namespace spelunker::thickmaze {
          */
         const ThickMaze reverse() const;
 
+        /// Make a ThickMaze into a braid maze, clearing dead ends with the given probability.
+        /**
+         * A braid maze is a maze with no dead ends: it will necessarily contain loops, and thus not be perfect.
+         *
+         * This method takes the current maze, and begins by creating a list of all the dead ends.
+         * The list is then shuffled, and one-by-one, the algorithm considers each dead end cell and does the following:
+         * 1. Determine if it is still indeed a dead end cell, as one of its walls may have already been removed.
+         * 2. Use probability to determine if we apply braiding to this cell.
+         * 3. Amongst the one-to-three neighbouring wall cells of this cell, pick one of the neighbours that
+         *    eliminates more dead ends than any other. If multiple cells with the same count exist, pick randomly.
+         * 4. Delete the wall cell.
+         *
+         * The reason for step (3) is because this allows us to minimize wall reduction, attempting to possibly
+         * fix two dead ends at the same time (this cell, and the neighbour cell).
+         *
+         * @param probability the probability of fixing a given dead end
+         * @return a new maze with walls removed to decrease the number of dead ends
+         */
+        const ThickMaze braid(double probability = 1.0) const;
+
+        /// Find the dead ends for this maze.
+        /**
+         * Find a collection of all the dead ends for this maze.
+         * A cell is considered a "dead end" if it has exactly three walls.
+         * @return a collection of the dead end cells
+         */
+        const types::CellCollection findDeadEnds() const noexcept;
+
     private:
+        /// Determine the number of walls a cell has for an instance of Contents.
+        /**
+         * Determine the number of walls a cell has for an instance of Contents.
+         * We allow Contents to be supplied for operations like {@see braid}, where we want to
+         * be working on an intermediate new CellContents.
+         * @param c the cell of interest
+         * @param cc the CellContents to use in counting
+         * @return the number of cell walls of c in cc
+         */
+        int numCellWallsInContents(const types::Cell &c, const CellContents &cc) const;
+
+        /**
+         * Check a cell to make sure it appears in a valid place.
+         * @param c the cell to check
+         */
+        void checkCell(const types::Cell &c) const;
+
         const int width;
         const int height;
         const CellContents contents;


### PR DESCRIPTION
`ThickMazes` may now be braided. Here is an example of a `ThickMaze` that was created via homomorphism from a `DFSMazeGenerator` and then braided:

<img width="767" alt="screen shot 2018-06-01 at 7 13 41 am" src="https://user-images.githubusercontent.com/8795653/40838323-b7f41f74-656b-11e8-8424-754e8c3170ce.png">
