### PR TITLE
T45: Fixed bug where wall cells could be considered dead ends.

### DIFF
--- a/src/thickmaze/ThickMaze.cpp
+++ b/src/thickmaze/ThickMaze.cpp
@@ -108,7 +108,7 @@ namespace spelunker::thickmaze {
         for (auto y = 0; y < height; ++y) {
             for (auto x = 0; x < width; ++x) {
                 const auto c = types::cell(x, y);
-                if (numCellWalls(c) == 3)
+                if (contents[x][y] == FLOOR && numCellWalls(c) == 3)
                     deadends.emplace_back(c);
             }
         }


### PR DESCRIPTION
I forgot to only consider floor cells as dead ends, and thus too many walls were removed during braiding. Here is an example of the correct output:
<img width="660" alt="screen shot 2018-06-01 at 7 28 43 am" src="https://user-images.githubusercontent.com/8795653/40838841-de5d6eac-656d-11e8-927a-4e3daa2a8f03.png">

