### PR TITLE
T54: Added storing of grid colour seeds to avoid repeats using Show.

### DIFF
--- a/src/thickmaze/GridColouring.cpp
+++ b/src/thickmaze/GridColouring.cpp
@@ -9,7 +9,10 @@
 #include <map>
 #include <numeric>
 #include <queue>
+#include <set>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #ifdef DEBUG
@@ -17,6 +20,7 @@
 using namespace std;
 #endif
 
+#include "typeclasses/Show.h"
 #include "types/CommonMazeAttributes.h"
 #include "math/Partition.h"
 #include "GridColouring.h"
@@ -87,6 +91,13 @@ namespace spelunker::thickmaze {
                                                                                      GridColouring::AbortPrematurely &aborter) const {
         // Brute-force all possibilities, of which there are many.
         std::vector<CandidateConfiguration> configurations;
+
+        // We want to keep track of ones we've already seen and not produce them again.
+        // There's probably a better way to do this than construct strings, but at least
+        // strings allow us larger number of colours than would otherwise be available
+        // to us through bitwise operations. Right now we use a base=64 representation
+        // implemented in the Show<CandidateConfiguration> typeclass.
+        std::set<std::string> seen;
 
         // Iterate over the candidates for room colour.
         bool aborted = false;
@@ -237,7 +248,13 @@ namespace spelunker::thickmaze {
                     }
                     cout << endl;
 #endif
+                    // Create the configuration, convert it to a string format, and skip it if we've already seen it.
                     CandidateConfiguration c{room, walls};
+                    auto str = typeclasses::Show<CandidateConfiguration>::show(c);
+                    if (seen.find(str) != seen.end())
+                        continue;
+                    seen.insert(str);
+
                     configurations.emplace_back(c);
                     if (aborter(c)) {
                         aborted = true;

--- a/src/thickmaze/GridColouring.h
+++ b/src/thickmaze/GridColouring.h
@@ -10,11 +10,14 @@
 
 #include <functional>
 #include <map>
+#include <sstream>
+#include <string>
 #include <tuple>
 #include <vector>
 
 #include <types/CommonMazeAttributes.h>
 #include "math/Partition.h"
+#include "typeclasses/Show.h"
 
 namespace spelunker::thickmaze {
     class GridColouring final {
@@ -172,5 +175,24 @@ namespace spelunker::thickmaze {
          * @return true if the cells are contiguous, and false otherwise.
          */
         bool isContiguous(const ColourCollection &colours) const;
+    };
+}
+
+namespace spelunker::typeclasses {
+    template<>
+    struct Show<thickmaze::GridColouring::CandidateConfiguration> {
+        // Encode in base-64.
+        static constexpr int base = 64;
+        static constexpr char nums[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        static std::string show(const thickmaze::GridColouring::CandidateConfiguration &c) {
+            std::ostringstream out;
+            out << nums[c.roomColour % base];
+            for (auto i=0; i < c.walls.size(); ++i) {
+                for (auto r: c.walls[i])
+                    out << nums[r % base];
+                if (i < c.walls.size()-1) out << "|";
+            }
+            return out.str();
+        }
     };
 }

--- a/src/thickmaze/GridColouringThickMazeGenerator.cpp
+++ b/src/thickmaze/GridColouringThickMazeGenerator.cpp
@@ -192,7 +192,7 @@ namespace spelunker::thickmaze {
             }
         }
 
-        assert(rooms.size() > 0 && rooms.size() <= 2);
+        //assert(rooms.size() > 0 && rooms.size() <= 2);
         return rooms;
     }
 


### PR DESCRIPTION
As it turns out, the partitioning algorithm was leading, through our filtering requirements, to many equivalent values. (An extreme case: 5 1 2 generated 17,360 configurations, but only 340 of them are unique.)

I implemented a `Show` typeclass instance for `CandidateConfiguration` that encodes in base-64, which should be sufficient because even low numbers of colours, e.g. 10, are time consuming to handle. `CandidateConfiguration`s are now converted into `string`s and stored in a `set` to check for repetitions, in which case, we discard them.