### PR TITLE
T53: Fixed major performance mistake and now outputting name of colour configs.

### DIFF
--- a/apps/grid_colouring.cpp
+++ b/apps/grid_colouring.cpp
@@ -60,8 +60,10 @@ int main(int argc, char *argv[]) {
 
     auto candidates = gc.wallCandidates();
     for (auto i=0; i < candidates.size(); ++i) {
-        std::cout << "************* CANDIDATE " << i << " **********" << std:: endl;
-        auto candidate = gc.wallCandidates()[i];
+        auto candidate = candidates[i];
+        std::cout << "************* CANDIDATE " << i << " (" <<
+                  spelunker::typeclasses::Show<spelunker::thickmaze::GridColouring::CandidateConfiguration>::show(candidate) <<
+                  ") **********" << std:: endl;
         spelunker::thickmaze::GridColouringThickMazeGenerator gen(width, height, gc, candidate);
         spelunker::thickmaze::ThickMaze tm = gen.generate();
         std::cout << spelunker::typeclasses::Show<spelunker::thickmaze::ThickMaze>::show(tm);


### PR DESCRIPTION
Fixed a very stupid and embarrassing performance mistake.

Also, now in headline for structures, ID is shown.