### PR TITLE
T62: Added GraphMaze class and isomorphism between Maze and GraphMaze. Refactored out typeclasses.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(wilson LINK_PUBLIC spelunker)
 add_executable(test_braid test_braid.cpp)
 target_link_libraries(test_braid LINK_PUBLIC spelunker)
 
+add_executable(test_isomorphism test_isomorphism.cpp)
+target_link_libraries(test_isomorphism LINK_PUBLIC spelunker)
+
 add_executable(test_thickbraid test_thickbraid.cpp)
 target_link_libraries(test_thickbraid LINK_PUBLIC spelunker)
 

--- a/apps/Executor.h
+++ b/apps/Executor.h
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
 #include "typeclasses/Show.h"
 #include "Utils.h"
 

--- a/apps/ProbabilisticExecutor.h
+++ b/apps/ProbabilisticExecutor.h
@@ -12,6 +12,7 @@
 #include <iostream>
 
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
 #include "typeclasses/Show.h"
 #include "Utils.h"
 

--- a/apps/cellular_automaton.cpp
+++ b/apps/cellular_automaton.cpp
@@ -11,6 +11,7 @@
 #include "thickmaze/CellularAutomatonThickMazeGenerator.h"
 #include "typeclasses/Show.h"
 #include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeTypeclasses.h"
 using namespace spelunker::thickmaze;
 
 int main(int argc, char *argv[]) {

--- a/apps/eller.cpp
+++ b/apps/eller.cpp
@@ -10,9 +10,10 @@
 
 #include <iostream>
 
-#include "maze/Maze.h"
-#include "typeclasses/Show.h"
 #include "maze/EllerMazeGenerator.h"
+#include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
+#include "typeclasses/Show.h"
 #include "Utils.h"
 
 int main(int argc, char *argv[]) {

--- a/apps/grid_colouring.cpp
+++ b/apps/grid_colouring.cpp
@@ -9,6 +9,7 @@
 #include "thickmaze/GridColouring.h"
 #include "thickmaze/GridColouringThickMazeGenerator.h"
 #include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeTypeclasses.h"
 #include "typeclasses/Show.h"
 #include "Utils.h"
 

--- a/apps/growing_tree.cpp
+++ b/apps/growing_tree.cpp
@@ -10,9 +10,10 @@
 
 #include <iostream>
 
-#include "maze/Maze.h"
-#include "typeclasses/Show.h"
 #include "maze/GrowingTreeMazeGenerator.h"
+#include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
+#include "typeclasses/Show.h"
 #include "Utils.h"
 
 int main(int argc, char *argv[]) {

--- a/apps/test_braid.cpp
+++ b/apps/test_braid.cpp
@@ -11,6 +11,7 @@ using namespace std;
 
 #include "maze/DFSMazeGenerator.h"
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
 #include "typeclasses/Show.h"
 
 int main(int argc, char *argv[]) {

--- a/apps/test_isomorphism.cpp
+++ b/apps/test_isomorphism.cpp
@@ -1,0 +1,33 @@
+/**
+ * test_isomorphism.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Test the isomorphism between Maze and GraphMaze.
+ */
+
+#include <iostream>
+
+#include "maze/DFSMazeGenerator.h"
+#include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
+#include "graphmaze/GraphMaze.h"
+#include "graphmaze/GraphMazeTypeclasses.h"
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
+
+int main(int argc, char *argv[]) {
+    spelunker::maze::DFSMazeGenerator gen(50,40);
+    spelunker::maze::Maze m = gen.generate();
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m);
+    std::cout << std::endl;
+
+    spelunker::graphmaze::GraphMaze gm = spelunker::typeclasses::Homomorphism<spelunker::maze::Maze, spelunker::graphmaze::GraphMaze>::morph(m);
+    std::cout << spelunker::typeclasses::Show<spelunker::graphmaze::GraphMaze>::show(gm);
+    std::cout << std::endl;
+
+    spelunker::maze::Maze m2 = spelunker::typeclasses::Homomorphism<spelunker::graphmaze::GraphMaze, spelunker::maze::Maze>::morph(gm);
+    std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m2);
+
+    return 0;
+}

--- a/apps/test_thickbraid.cpp
+++ b/apps/test_thickbraid.cpp
@@ -6,7 +6,9 @@
 
 #include "maze/DFSMazeGenerator.h"
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
 #include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeTypeclasses.h"
 #include "typeclasses/Homomorphism.h"
 #include "typeclasses/Show.h"
 

--- a/apps/test_thickify.cpp
+++ b/apps/test_thickify.cpp
@@ -7,8 +7,10 @@
 #include <iostream>
 
 #include "maze/DFSMazeGenerator.h"
-#include "thickmaze/ThickMaze.h"
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
+#include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeTypeclasses.h"
 #include "typeclasses/Homomorphism.h"
 #include "typeclasses/Show.h"
 

--- a/apps/test_unicursal.cpp
+++ b/apps/test_unicursal.cpp
@@ -9,6 +9,7 @@ using namespace std;
 
 #include "maze/DFSMazeGenerator.h"
 #include "maze/Maze.h"
+#include "maze/MazeTypeclasses.h"
 #include "typeclasses/Show.h"
 
 int main(int argc, char *argv[]) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file(
 )
 
 set(SUBDIRS
+        graphmaze
         math
         maze
         thickmaze
@@ -20,6 +21,7 @@ foreach(d ${SUBDIRS})
 endforeach()
 
 set(PUBLIC_HEADER_FILES
+        ${GRIDMAZE_PUBLIC_HEADER_FILES}
         ${MATH_PUBLIC_HEADER_FILES}
         ${MAZE_PUBLIC_HEADER_FILES}
         ${THICKMAZE_PUBLIC_HEADER_FILES}
@@ -29,6 +31,7 @@ set(PUBLIC_HEADER_FILES
         )
 
 set(PRIVATE_HEADER_FILES
+        ${GRIDMAZE_PRIVATE_HEADER_FILES}
         ${MATH_PRIVATE_HEADER_FILES}
         ${MAZE_PRIVATE_HEADER_FILES}
         ${THICKMAZE_PRIVATE_HEADER_FILES}
@@ -37,6 +40,7 @@ set(PRIVATE_HEADER_FILES
         )
 
 set(SOURCE_FILES
+        ${GRIDMAZE_SOURCE_FILES}
         ${MATH_SOURCE_FILES}
         ${MAZE_SOURCE_FILES}
         ${TYPES_SOURCE_FILES}

--- a/src/graphmaze/CMakeLists.txt
+++ b/src/graphmaze/CMakeLists.txt
@@ -1,0 +1,24 @@
+# CMakeLists
+# By Sebastian Raaphorst, 2018.
+
+set(_GRIDMAZE_PUBLIC_HEADER_FILES
+        GraphMaze.h
+        GraphMazeAttributes.h
+        GraphMazeTypeclasses.h
+        )
+
+set(_GRIDMAZE_PRIVATE_HEADER_FILES
+        )
+
+set(_GRIDMAZE_SOURCE_FILES
+        GraphMaze.cpp
+        )
+
+src_dir_filelist("${_GRIDMAZE_PUBLIC_HEADER_FILES}" outlst)
+set(GRIDMAZE_PUBLIC_HEADER_FILES "${outlst}" PARENT_SCOPE)
+
+src_dir_filelist("${_GRIDMAZE_PRIVATE_HEADER_FILES}" outlst)
+set(GRIDMAZE_PRIVATE_HEADER_FILES "${outlst}" PARENT_SCOPE)
+
+src_dir_filelist("${_GRIDMAZE_SOURCE_FILES}" outlst)
+set(GRIDMAZE_SOURCE_FILES "${outlst}" PARENT_SCOPE)

--- a/src/graphmaze/GraphMaze.cpp
+++ b/src/graphmaze/GraphMaze.cpp
@@ -1,0 +1,41 @@
+/**
+ * GraphMaze.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <optional>
+#include <vector>
+
+#include <boost/graph/adjacency_list.hpp>
+
+#include "types/CommonMazeAttributes.h"
+#include "types/Exceptions.h"
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
+#include "maze/Maze.h"
+#include "GraphMazeAttributes.h"
+#include "GraphMaze.h"
+
+namespace spelunker::graphmaze {
+    GraphMaze::GraphMaze(int w,
+                         int h,
+                         const types::PossibleCell &s,
+                         const types::CellCollection &ends,
+                         const VertexCellPathCollection &ps)
+            : width{w}, height{h}, startCell{s}, endingCells{ends},
+              vertices{createVertexCellGrid(w, h)},
+              lookup{createCellLookup(w, h)},
+              graph{graphFromPaths(w*h, ps)} {}
+
+    GraphMaze::GraphMaze(int w, int h, const spelunker::graphmaze::VertexCellPathCollection &ps)
+        : GraphMaze{w, h, {}, types::CellCollection(), ps} {}
+
+
+    GridGraph GraphMaze::graphFromPaths(const vertex_size_t numcells,
+                                        const VertexCellPathCollection &ps) {
+        for (auto iter = ps.begin(); iter != ps.end(); ++iter)
+            auto [v1,v2] = *iter;
+        return GridGraph{ps.begin(), ps.end(), numcells};
+    }
+}

--- a/src/graphmaze/GraphMaze.h
+++ b/src/graphmaze/GraphMaze.h
@@ -1,0 +1,67 @@
+/**
+ * GraphMaze.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * A representation of a thin maze using Boost's graph library.
+ */
+
+#pragma once
+
+#include "types/CommonMazeAttributes.h"
+#include "GraphMazeAttributes.h"
+#include <boost/graph/adjacency_list.hpp>
+
+namespace spelunker::graphmaze {
+    /**
+     * A representation of thin Maze using Boost's graph library isomorphic to Maze.
+     *
+     * Note that whereas in Maze, we store a collection of walls, in the graph representation
+     * of a maze, we have one vertex per maze cell and edges represent the absence of a wall
+     * between two cells, i.e. a path.
+     */
+    class GraphMaze final {
+    public:
+        /// Create a graph maze bounded by width and height, with a start and end position.
+        GraphMaze(int w,
+                  int h,
+                  const types::PossibleCell &s,
+                  const types::CellCollection &ends,
+                  const VertexCellPathCollection &ps);
+
+        /// Creates a maze bounded by width and height, but with no start / end positions.
+        GraphMaze(int w,
+                  int h,
+                  const VertexCellPathCollection &ps);
+
+        ~GraphMaze() = default;
+
+        inline const int getWidth() const noexcept { return width; }
+        inline const int getHeight() const noexcept { return height; }
+
+        inline const GridGraph &getUnderlyingGraph() const noexcept { return graph; }
+
+        inline const CellFromVertexCellMap getCellLookup() const noexcept { return lookup; }
+
+        inline types::PossibleCell getStartingCell() const noexcept  { return startCell; }
+
+        inline types::CellCollection getEndingCells() const noexcept { return endingCells; }
+
+    private:
+        static GridGraph graphFromPaths(vertex_size_t numcells, const VertexCellPathCollection &ps);
+
+        const int width;
+        const int height;
+
+        const types::PossibleCell startCell;
+        const types::CellCollection endingCells;
+
+        const GridGraph graph;
+
+        // The matrix of vertices: maps (row,col) to vertex.
+        VertexCellGrid vertices;
+
+        // The reverse lookup: maps vertex to (row,col).
+        CellFromVertexCellMap lookup;
+    };
+}

--- a/src/graphmaze/GraphMazeAttributes.h
+++ b/src/graphmaze/GraphMazeAttributes.h
@@ -1,0 +1,90 @@
+/**
+ * GraphMazeAttributes.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Attributes used by GraphMazes.
+ */
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <boost/graph/adjacency_list.hpp>
+
+#include "types/Exceptions.h"
+#include "types/CommonMazeAttributes.h"
+
+namespace spelunker::graphmaze {
+    /// The representation of a cell, which is a vertex in the graph.
+    using VertexCell = int;
+
+    /// A possible cell, used to represent, for example, the start vertex.
+    using PossibleVertexCell = std::optional<VertexCell>;
+
+    /// A collection or row of VertexCells.
+    using VertexCellCollection = std::vector<VertexCell>;
+
+    /// A matrix of VertexCells, used to represent the grid that is a graph's cells.
+    using VertexCellGrid = std::vector<VertexCellCollection>;
+
+    /// A reverse lookup table, to map graph vertices to cell positions.
+    using CellFromVertexCellMap = std::vector<types::Cell>;
+
+    /// A valid path in the maze, from one cell to another.
+    using VertexCellPath = std::pair<VertexCell, VertexCell>;
+
+    /// A collection of paths, used as graph edges in a GraphMaze.
+    using VertexCellPathCollection = std::vector<VertexCellPath>;
+
+    /// The type of a grid graph, which is a simple graph.
+    using GridGraph = boost::adjacency_list<boost::setS, boost::vecS, boost::undirectedS>;
+
+    /// The type of the number of vertices in a graph.
+    using vertex_size_t = GridGraph::vertices_size_type;
+
+    /// Creates a matrix of VertexCells, increasing along rows.
+    /**
+     * Creates a matrix of VertexCells, increasing along rows. Paths in a GridGraph
+     * should respect this pattern for consistency.
+     * @param width width of the grid
+     * @param height height of the grid
+     * @return an initialized grid with position (0,0) = 0 and increasing along rows
+     */
+    inline const VertexCellGrid createVertexCellGrid(int width, int height) {
+        if (width <= 0 || height <= 0)
+            throw types::IllegalDimensions(width, height);
+
+        VertexCellGrid m(height);
+        auto v = 0;
+        for (auto y=0; y < height; ++y) {
+            VertexCellCollection row(width);
+            for (auto x=0; x < width; ++x)
+                row[x] = v++;
+            m[y] = row;
+        }
+        return m;
+    }
+
+    /**
+     * Creates a reverse lookup to createVertexCellGrid, i.e. takes a vertex number
+     * and returns the pair (row,col) in which the vertex appears in the grid.
+     * @param width the width of the grid
+     * @param height the height of the grid
+     * @return
+     */
+    inline const CellFromVertexCellMap createCellLookup(int width, int height) {
+        if (width <= 0 || height <= 0)
+            throw types::IllegalDimensions(width, height);
+
+        CellFromVertexCellMap m(width * height);
+        auto v = 0;
+        for (VertexCell y=0; y < height; ++y)
+            for (VertexCell x=0; x < width; ++x)
+                m[v++] = std::make_pair(x, y);
+
+        return m;
+    }
+};

--- a/src/graphmaze/GraphMazeTypeclasses.h
+++ b/src/graphmaze/GraphMazeTypeclasses.h
@@ -1,0 +1,57 @@
+/**
+ * GraphMazeTypeclasses.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+#include <boost/graph/adjacency_list.hpp>
+
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
+#include "maze/Maze.h"
+#include "maze/MazeAttributes.h"
+#include "GraphMaze.h"
+#include "GraphMazeAttributes.h"
+
+namespace spelunker::typeclasses {
+    template<>
+    struct Homomorphism<graphmaze::GraphMaze, maze::Maze> {
+        static const maze::Maze morph(const graphmaze::GraphMaze &m) {
+            const auto w = m.getWidth();
+            const auto h = m.getHeight();
+
+            // Start with all walls, and remove them as we iterate over the paths.
+            auto numWalls = maze::calculateNumWalls(w, h);
+            maze::WallIncidence wi(numWalls, true);
+
+            auto lookup = m.getCellLookup();
+            auto [eit, eend] = boost::edges(m.getUnderlyingGraph());
+            for (; eit != eend; ++eit) {
+                auto e = *eit;
+                auto v1 = e.m_source;
+                auto v2 = e.m_target;
+                auto [x1,y1] = lookup[v1];
+                auto [x2,y2] = lookup[v2];
+                auto d = types::cellDirection(types::cell(x1,y1), types::cell(x2,y2));
+
+                // Now carve the corresponding wall out of wc.
+                auto wallID = maze::Maze::rankPositionS(w, h, x1, y1, d);
+                wi[wallID] = false;
+            }
+
+            return maze::Maze(w, h, m.getStartingCell(), m.getEndingCells(), wi);
+        }
+    };
+
+    template<>
+    struct Show<graphmaze::GraphMaze> {
+        static std::string show(const graphmaze::GraphMaze &gm) {
+            auto m = Homomorphism<graphmaze::GraphMaze, maze::Maze>::morph(gm);
+            return Show<maze::Maze>::show(m);
+        }
+    };
+}

--- a/src/maze/CMakeLists.txt
+++ b/src/maze/CMakeLists.txt
@@ -14,6 +14,7 @@ set(_MAZE_PUBLIC_HEADER_FILES
         MazeAttributes.h
         MazeGenerator.h
         MazeRenderer.h
+        MazeTypeclasses.h
         PrimMazeGenerator.h
         Prim2MazeGenerator.h
         RecursiveDivisionMazeGenerator.h

--- a/src/maze/Maze.cpp
+++ b/src/maze/Maze.cpp
@@ -422,7 +422,7 @@ namespace spelunker::maze {
             throw types::OutOfBoundsCell(types::Cell(x, y));
     }
 
-#ifndef NDEBUG
+#ifdef DEBUG
 
     void Maze::test_rankPositionS(const int w, const int h) {
         std::set<int> ranks;

--- a/src/maze/MazeGenerator.cpp
+++ b/src/maze/MazeGenerator.cpp
@@ -88,7 +88,7 @@ namespace spelunker::maze {
         return nbrs;
     }
 
-#ifndef NDEBUG
+#ifndef DEBUG
     void MazeGenerator::test_createUnrankWallMapS(const int w, const int h) {
         const auto m = createUnrankWallMapS(w, h);
         for (auto kv : m) {

--- a/src/maze/MazeGenerator.h
+++ b/src/maze/MazeGenerator.h
@@ -78,7 +78,7 @@ namespace spelunker::maze {
         const types::Neighbours neighbours(const types::Cell &c,
                                            std::function<bool(const int, const int)> filter) const;
 
-#ifndef NDEBUG
+#ifndef DEBUG
     public:
         /// Static test case for the createUnrankWallMapS function.
         static void test_createUnrankWallMapS(int w, int h);

--- a/src/maze/MazeTypeclasses.h
+++ b/src/maze/MazeTypeclasses.h
@@ -1,0 +1,107 @@
+/**
+ * MazeTypeclasses.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "types/CommonMazeAttributes.h"
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
+#include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeAttributes.h"
+#include "graphmaze/GraphMaze.h"
+#include "graphmaze/GraphMazeAttributes.h"
+#include "Maze.h"
+#include "MazeAttributes.h"
+#include "StringMazeRenderer.h"
+
+namespace spelunker::typeclasses {
+    template<>
+    struct Show<maze::Maze> {
+        static std::string show(const maze::Maze &m) {
+            std::ostringstream out;
+            maze::StringMazeRenderer r(out);
+            r.render(m);
+            return out.str();
+        }
+
+        static constexpr bool is_instance = true;
+        using type = maze::Maze;
+    };
+
+    template<>
+    struct Homomorphism<maze::Maze, thickmaze::ThickMaze> {
+        static const thickmaze::ThickMaze morph(const maze::Maze &m) {
+            const auto mwidth  = m.getWidth();
+            const auto mheight = m.getHeight();
+            const auto twidth  = 2 * mwidth - 1;
+            const auto theight = 2 * mheight - 1;
+
+            auto contents = thickmaze::createThickMazeCellContents(twidth, theight);
+
+            // Iterate over the walls of the maze and add them to the thick maze, focusing
+            // on the east and the south walls of maze.
+            // For each maze wall, mark (provided not out of bounds) three wall segments
+            // in the thick maze.
+            for (auto x = 0; x < mwidth; ++x)
+                for (auto y = 0; y < mheight; ++y) {
+                    // Ignore the last row of maze when adding southern walls.
+                    if (y < mheight-1 && m.wall(x, y, SOUTH)) {
+                        // Find the central position in the thick maze.
+                        const int cx = 2 * x;
+                        const int cy = 2 * y + 1;
+                        if (cx > 0) contents[cx-1][cy] = thickmaze::WALL;
+                        contents[cx][cy] = thickmaze::WALL;
+                        if (cx < twidth-1) contents[cx+1][cy] = thickmaze::WALL;
+                    }
+
+                    // Ignore the last row of maze when adding eastern walls.
+                    if (x < mwidth - 1 && m.wall(x, y, EAST)) {
+                        // Find the central position in the thick maze.
+                        const int cx = 2 * x + 1;
+                        const int cy = 2 * y;
+                        if (cy > 0) contents[cx][cy-1] = thickmaze::WALL;
+                        contents[cx][cy] = thickmaze::WALL;
+                        if (cy < theight-1) contents[cx][cy+1] = thickmaze::WALL;
+                    }
+                }
+            return thickmaze::ThickMaze(twidth, theight, contents);
+        }
+
+        static constexpr bool is_instance = true;
+        using src = maze::Maze;
+        using type = thickmaze::ThickMaze;
+    };
+
+    template<>
+    struct Homomorphism<maze::Maze, graphmaze::GraphMaze> {
+        static const graphmaze::GraphMaze morph(const maze::Maze &m) {
+            const auto w = m.getWidth();
+            const auto h = m.getHeight();
+            graphmaze::VertexCellPathCollection vc;
+
+            // Iterate over the walls of this maze and if they are carved out, add
+            // them to the list of paths. Only deal with east and south walls since
+            // other directions are just repeats of those two.
+            const auto maxH = h - 1;
+            const auto maxW = w - 1;
+            int v = 0;
+            for (auto y=0; y < h; ++y)
+                for (auto x=0; x < w; ++x) {
+                    if (!m.wall(types::pos(x, y, types::EAST)))
+                        vc.emplace_back(v, v + 1);
+                    if (!m.wall(types::pos(x, y, types::SOUTH)))
+                        vc.emplace_back(v, v + w);
+                    ++v;
+                }
+
+            return graphmaze::GraphMaze(w, h, m.getStartingCell(), m.getEndingCells(), vc);
+        }
+    };
+}

--- a/src/thickmaze/CMakeLists.txt
+++ b/src/thickmaze/CMakeLists.txt
@@ -10,6 +10,7 @@ set(_THICKMAZE_PUBLIC_HEADER_FILES
         ThickMazeAttributes.h
         ThickMazeGenerator.h
         ThickMazeRenderer.h
+        ThickMazeTypeclasses.h
         )
 
 set(_THICKMAZE_PRIVATE_HEADER_FILES

--- a/src/thickmaze/ThickMaze.h
+++ b/src/thickmaze/ThickMaze.h
@@ -11,9 +11,7 @@
 #include <sstream>
 #include <string>
 
-#include "typeclasses/Show.h"
 #include "ThickMazeAttributes.h"
-#include "StringThickMazeRenderer.h"
 
 namespace spelunker::thickmaze {
     /**
@@ -104,17 +102,5 @@ namespace spelunker::thickmaze {
         const int width;
         const int height;
         const CellContents contents;
-    };
-}
-
-namespace spelunker::typeclasses {
-    template<>
-    struct Show<thickmaze::ThickMaze> {
-        static std::string show(const thickmaze::ThickMaze &tm) {
-            std::ostringstream out;
-            thickmaze::StringThickMazeRenderer r(out);
-            r.render(tm);
-            return out.str();
-        }
     };
 }

--- a/src/thickmaze/ThickMazeTypeclasses.h
+++ b/src/thickmaze/ThickMazeTypeclasses.h
@@ -1,0 +1,27 @@
+/**
+ * ThickMazeTypeclasses.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+#include "typeclasses/Show.h"
+#include "ThickMazeAttributes.h"
+#include "ThickMaze.h"
+#include "StringThickMazeRenderer.h"
+
+namespace spelunker::typeclasses {
+    template<>
+    struct Show<thickmaze::ThickMaze> {
+        static std::string show(const thickmaze::ThickMaze &tm) {
+            std::ostringstream out;
+            thickmaze::StringThickMazeRenderer r(out);
+            r.render(tm);
+            return out.str();
+        }
+    };
+}

--- a/src/types/CommonMazeAttributes.h
+++ b/src/types/CommonMazeAttributes.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -33,6 +34,24 @@ namespace spelunker::types {
         SOUTH,
         WEST,
     };
+
+    /// Determine what direction two adjacent cells are apart.
+    inline Direction cellDirection(const Cell &c1, const Cell &c2) {
+        auto [x1, y1] = c1;
+        auto [x2, y2] = c2;
+
+        if (x1 - x2 == -1 && y1 == y2)
+            return EAST;
+        if (x1 - x2 ==  1 && y1 == y2)
+            return WEST;
+        if (y1 - y2 == -1 && x1 == x2)
+            return SOUTH;
+        if (y1 - y2 ==  1 && x1 == x2)
+            return NORTH;
+
+        // If we reach this point, the cells aren't adjacent.
+        throw std::domain_error("Vertices are not adjacent");
+    }
 
     /// Flip a direction.
     inline Direction flip(const Direction d) {


### PR DESCRIPTION
There is now a package, `GraphMaze`, which uses Boost.Graph to represent thin mazes. In order to test it, I implemented the typeclasses `Homomorphism` from `GraphMaze` to `Maze` and vice-versa (since it is an isomorphism), and `Show` for `GraphMaze`, which just maps through the homomorphism to `Maze` and uses `Show<Maze>`.

This appears to be working fine, as verified in the `test_isomorphism` app, which takes a DFS `Maze`, isomorphically maps it to a `GraphMaze`, `show`s it (which uses the reverse homomorphism), and then explicitly calls the isomorphism to map the `GraphMaze` back to the `Maze`, and `show`s that. The results are consistent.