### PR TITLE
T77: Added identity homomorphism.

### DIFF
--- a/src/graphmaze/GraphMazeTypeclasses.h
+++ b/src/graphmaze/GraphMazeTypeclasses.h
@@ -45,6 +45,10 @@ namespace spelunker::typeclasses {
 
             return maze::Maze(w, h, m.getStartingCell(), m.getEndingCells(), wi);
         }
+
+        static constexpr bool is_instance = true;
+        using src  = graphmaze::GraphMaze;
+        using dest = maze::Maze;
     };
 
     template<>
@@ -53,5 +57,8 @@ namespace spelunker::typeclasses {
             auto m = Homomorphism<graphmaze::GraphMaze, maze::Maze>::morph(gm);
             return Show<maze::Maze>::show(m);
         }
+
+        static constexpr bool is_instance = true;
+        using type = graphmaze::GraphMaze;
     };
 }

--- a/src/maze/MazeTypeclasses.h
+++ b/src/maze/MazeTypeclasses.h
@@ -75,8 +75,8 @@ namespace spelunker::typeclasses {
         }
 
         static constexpr bool is_instance = true;
-        using src = maze::Maze;
-        using type = thickmaze::ThickMaze;
+        using src  = maze::Maze;
+        using dest = thickmaze::ThickMaze;
     };
 
     template<>
@@ -103,5 +103,9 @@ namespace spelunker::typeclasses {
 
             return graphmaze::GraphMaze(w, h, m.getStartingCell(), m.getEndingCells(), vc);
         }
+
+        static constexpr bool is_instance = true;
+        using src  = maze::Maze;
+        using dest = graphmaze::GraphMaze;
     };
 }

--- a/src/thickmaze/ThickMazeTypeclasses.h
+++ b/src/thickmaze/ThickMazeTypeclasses.h
@@ -23,5 +23,8 @@ namespace spelunker::typeclasses {
             r.render(tm);
             return out.str();
         }
+
+        static constexpr bool is_instance = true;
+        using type = thickmaze::ThickMaze;
     };
 }

--- a/src/typeclasses/Homomorphism.h
+++ b/src/typeclasses/Homomorphism.h
@@ -13,9 +13,23 @@ namespace spelunker::typeclasses {
      */
      template<typename S, typename T>
      struct Homomorphism {
-         // std::T morph(S);
+         // static const T morph(const S&);
          static constexpr bool is_instance = false;
          using src = S;
-         using type = T;
+         using dest = T;
      };
+
+     /**
+      * The trivial homomorphism from an object to itself.
+      */
+      template<typename T>
+      struct Homomorphism<T, T> {
+          static const T morph(const T &o) {
+              return o;
+          }
+
+          static constexpr bool is_instance = true;
+          using src  = T;
+          using dest = T;
+      };
 }

--- a/src/typeclasses/Show.h
+++ b/src/typeclasses/Show.h
@@ -15,7 +15,7 @@ namespace spelunker::typeclasses {
      */
     template<typename T>
     struct Show {
-        // std::string show(T);
+        // static std::string show(const &T);
         static constexpr bool is_instance = false;
         using type = T;
     };


### PR DESCRIPTION
The base `Homomorphism` typeclass file now contains a definition for `Homomorphism<S,S>`.

This has the possible issue that anything - even things that don't necessarily make sense - have a homomorphism defined for them.