### PR TITLE
T78: Added CompositionHomomorphism, which works without need for specialization

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -49,8 +49,8 @@ target_link_libraries(wilson LINK_PUBLIC spelunker)
 add_executable(test_braid test_braid.cpp)
 target_link_libraries(test_braid LINK_PUBLIC spelunker)
 
-add_executable(test_isomorphism test_isomorphism.cpp)
-target_link_libraries(test_isomorphism LINK_PUBLIC spelunker)
+add_executable(test_homomorphisms test_homomorphisms.cpp)
+target_link_libraries(test_homomorphisms LINK_PUBLIC spelunker)
 
 add_executable(test_thickbraid test_thickbraid.cpp)
 target_link_libraries(test_thickbraid LINK_PUBLIC spelunker)

--- a/apps/test_homomorphisms.cpp
+++ b/apps/test_homomorphisms.cpp
@@ -8,13 +8,15 @@
 
 #include <iostream>
 
+#include "typeclasses/Homomorphism.h"
+#include "typeclasses/Show.h"
 #include "maze/DFSMazeGenerator.h"
 #include "maze/Maze.h"
 #include "maze/MazeTypeclasses.h"
 #include "graphmaze/GraphMaze.h"
 #include "graphmaze/GraphMazeTypeclasses.h"
-#include "typeclasses/Homomorphism.h"
-#include "typeclasses/Show.h"
+#include "thickmaze/ThickMaze.h"
+#include "thickmaze/ThickMazeTypeclasses.h"
 
 int main(int argc, char *argv[]) {
     spelunker::maze::DFSMazeGenerator gen(50,40);
@@ -28,6 +30,13 @@ int main(int argc, char *argv[]) {
 
     spelunker::maze::Maze m2 = spelunker::typeclasses::Homomorphism<spelunker::graphmaze::GraphMaze, spelunker::maze::Maze>::morph(gm);
     std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m2);
+    std::cout << std::endl;
 
+    // We also test the composition homomorphism
+    spelunker::thickmaze::ThickMaze tm =
+            spelunker::typeclasses::CompositionHomomorphism<spelunker::graphmaze::GraphMaze,
+                                                            spelunker::maze::Maze,
+                                                            spelunker::thickmaze::ThickMaze>::morph(gm);
+    std::cout << spelunker::typeclasses::Show<spelunker::thickmaze::ThickMaze>::show(tm);
     return 0;
 }

--- a/src/typeclasses/Homomorphism.h
+++ b/src/typeclasses/Homomorphism.h
@@ -11,25 +11,41 @@ namespace spelunker::typeclasses {
      * A homomorphism is a structure-preserving map.
      * This type class represents a map from one class to another.
      */
-     template<typename S, typename T>
-     struct Homomorphism {
-         // static const T morph(const S&);
-         static constexpr bool is_instance = false;
-         using src = S;
-         using dest = T;
-     };
+    template<typename S, typename T>
+    struct Homomorphism {
+        //static const T morph(const S&);
+        static constexpr bool is_instance = false;
+        using src = S;
+        using dest = T;
+    };
 
-     /**
-      * The trivial homomorphism from an object to itself.
-      */
-      template<typename T>
-      struct Homomorphism<T, T> {
-          static const T morph(const T &o) {
-              return o;
-          }
+    /**
+     * The trivial homomorphism from an object to itself.
+     */
+    template<typename T>
+    struct Homomorphism<T, T> {
+        static const T morph(const T &t) {
+            return t;
+        }
 
-          static constexpr bool is_instance = true;
-          using src  = T;
-          using dest = T;
-      };
+        static constexpr bool is_instance = true;
+        using src  = T;
+        using dest = T;
+    };
+
+    /**
+     * A composition homomorphism.
+     */
+    template<typename S, typename T, typename U,
+        typename HST = Homomorphism<S, T>,
+        typename HTU = Homomorphism<T, U> >
+    struct CompositionHomomorphism : public Homomorphism<S, U> {
+        static const U morph(const S &s) {
+            return HTU::morph(HST::morph(s));
+        }
+
+        static constexpr bool is_instance = true;
+        using src  = S;
+        using dest = U;
+    };
 }


### PR DESCRIPTION
Added `CompositionHomomorphism` to `Homomorphism`, which inherits from `Homomorphism` and needs no specialization in order to work:

`CompositionHomomorphism<S, T, U>::morph(const S &s)` works as long as there are:

* `Homomorphism<S,T>`
* `Homomorphism<T,U>`

in the current scope. In case the default homomorphisms don't want to be used, fourth and fifth parameters to `CompositionHomomorphism` can be added to serve as the aforementioned two homomorphisms.