### PR TITLE
T2: More test cases and a ThickMazeGeneratorByHomomorphism class

### DIFF
--- a/apps/test_thickify.cpp
+++ b/apps/test_thickify.cpp
@@ -20,6 +20,7 @@ int main(int argc, char *argv[]) {
     std::cout << spelunker::typeclasses::Show<spelunker::maze::Maze>::show(m);
 
     spelunker::thickmaze::ThickMaze tm = spelunker::typeclasses::Homomorphism<spelunker::maze::Maze, spelunker::thickmaze::ThickMaze>::morph(m);
+    std::cout << "ThickMaze has size: " << spelunker::typeclasses::Show<spelunker::types::Dimensions2D>::show(tm.getDimensions()) << std::endl;
     std::cout << spelunker::typeclasses::Show<spelunker::thickmaze::ThickMaze>::show(tm);
     return 0;
 }

--- a/src/maze/HuntAndKillMazeGenerator.cpp
+++ b/src/maze/HuntAndKillMazeGenerator.cpp
@@ -13,9 +13,6 @@
 #include "MazeGenerator.h"
 #include "HuntAndKillMazeGenerator.h"
 
-#include <iostream>
-using namespace std;
-
 namespace spelunker::maze {
     HuntAndKillMazeGenerator::HuntAndKillMazeGenerator(const types::Dimensions2D &d)
         : MazeGenerator{d} {}

--- a/src/maze/Maze.cpp
+++ b/src/maze/Maze.cpp
@@ -24,9 +24,6 @@
 #include "Maze.h"
 #include "MazeGenerator.h"
 
-#include <iostream>
-using namespace std;
-
 namespace spelunker::maze {
     Maze::Maze(const types::Dimensions2D &d,
                const types::PossibleCell &start,
@@ -407,27 +404,4 @@ namespace spelunker::maze {
         // Make the compiler happy.
         throw std::invalid_argument("Trying to rank illegal direction.");
     }
-
-#ifdef DEBUG
-    void Maze::test_rankPositionS(const spelunker::types::Dimensions2D &dim) {
-        std::set<int> ranks;
-        const auto numwalls = calculateNumWalls(dim);
-        const auto [width, height] = dim.values();
-
-        for (auto x = 0; x < width; ++x)
-            for (auto y = 0; y < height; ++y) {
-                for (auto dir: types::directions()) {
-                    const auto r = rankPositionS(dim, x, y, dir);
-                    if (r != -1) ranks.insert(r);
-                }
-                if (y > 0 && y < height - 1)
-                    assert(rankPositionS(dim, x, y, types::Direction::NORTH) == rankPositionS(dim, x, y - 1, types::Direction::SOUTH));
-                if (x > 0 && x < width - 1)
-                    assert(rankPositionS(dim, x - 1, y, types::Direction::EAST) == rankPositionS(dim, x, y, types::Direction::WEST));
-            }
-
-        for (auto i = 0; i < numwalls; ++i)
-            assert(ranks.find(i) != ranks.end());
-    }
-#endif
 }

--- a/src/maze/Maze.h
+++ b/src/maze/Maze.h
@@ -208,11 +208,5 @@ namespace spelunker::maze {
 
         const int numWalls;
         const WallIncidence wallIncidence;
-
-#ifdef DEBUG
-    public:
-        /// Static test case for the rankPositionS function.
-        static void test_rankPositionS(const types::Dimensions2D &dim);
-#endif
     };
 }

--- a/src/maze/MazeGenerator.cpp
+++ b/src/maze/MazeGenerator.cpp
@@ -19,10 +19,6 @@ namespace spelunker::maze {
     MazeGenerator::MazeGenerator(const int w, const int h)
         : MazeGenerator{types::Dimensions2D{w, h}} {}
 
-    const UnrankWallMap MazeGenerator::createUnrankWallMap() const noexcept {
-        return createUnrankWallMapS(getDimensions());
-    }
-
     const UnrankWallMap MazeGenerator::createUnrankWallMapS(const types::Dimensions2D &dim) noexcept {
         UnrankWallMap umap;
 
@@ -48,6 +44,10 @@ namespace spelunker::maze {
         }
 
         return umap;
+    }
+
+    const UnrankWallMap MazeGenerator::createUnrankWallMap() const noexcept {
+        return createUnrankWallMapS(getDimensions());
     }
 
     const WallID MazeGenerator::rankPos(const types::Position &p) const {
@@ -89,23 +89,4 @@ namespace spelunker::maze {
             nbrs.emplace_back(types::pos(x, y + 1, types::Direction::NORTH));
         return nbrs;
     }
-
-#ifdef DEBUG
-    void MazeGenerator::test_createUnrankWallMapS(const types::Dimensions2D &dim) {
-        const auto m = createUnrankWallMapS(dim);
-        for (const auto &kv : m) {
-            // kv is std::map<WallID, std::pair<types::Position, types::Position> >
-            const auto &[rk, ps] = kv;
-            const auto &[p1, p2] = ps;
-
-            const auto &[c1, d1] = p1;
-            const auto [x1, y1] = c1;
-            assert(Maze::rankPositionS(dim, x1, y1, d1) == rk);
-
-            const auto &[c2, d2] = p2;
-            const auto [x2, y2] = c2;
-            assert(Maze::rankPositionS(dim, x2, y2, d2) == rk);
-        }
-    }
-#endif
 }

--- a/src/maze/MazeGenerator.h
+++ b/src/maze/MazeGenerator.h
@@ -27,12 +27,12 @@ namespace spelunker::maze {
 
         virtual const Maze generate() const noexcept = 0;
 
+        /// A static function used by unrankWallID, separated out for testing.
+        static const UnrankWallMap createUnrankWallMapS(const types::Dimensions2D &dim) noexcept;
+
     protected:
         /// Create a map to reverse rankPosition: determine the two Positions on either side of a wall.
         const UnrankWallMap createUnrankWallMap() const noexcept;
-
-        /// A static function used by unrankWallID, separated out for testing.
-        static const UnrankWallMap createUnrankWallMapS(const types::Dimensions2D &dim) noexcept;
 
         /// A function that maps Position to the corresponding ID of the wall in the maze.
         const WallID rankPos(const types::Position &p) const;
@@ -74,12 +74,6 @@ namespace spelunker::maze {
          */
         const types::Neighbours neighbours(const types::Cell &c,
                                            std::function<bool(const int, const int)> filter) const;
-
-#ifdef DEBUG
-    public:
-        /// Static test case for the createUnrankWallMapS function.
-        static void test_createUnrankWallMapS(const types::Dimensions2D &dim);
-#endif
     };
 }
 

--- a/src/test/maze/CMakeLists.txt
+++ b/src/test/maze/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_executable(test_maze_symmetries TestMazeSymmetries.cpp ${TEST_SOURCES})
 target_link_libraries(test_maze_symmetries Catch spelunker)
+
+add_executable(test_rank_position TestRankPosition.cpp ${TEST_SOURCES})
+target_link_libraries(test_rank_position Catch spelunker)
+
+add_executable(test_unrank_wall_map TestUnrankWallMap.cpp ${TEST_SOURCES})
+target_link_libraries(test_unrank_wall_map Catch spelunker)

--- a/src/test/maze/MazeGenerators.h
+++ b/src/test/maze/MazeGenerators.h
@@ -28,8 +28,8 @@ using namespace spelunker;
 // Return a list of all MazeGenerators.
 using MazeGenerators = std::vector<maze::MazeGenerator*>;
 
-MazeGenerators createGenerators(const types::Dimensions2D &d) {
-    return std::vector<maze::MazeGenerator*> {
+MazeGenerators createMazeGenerators(const types::Dimensions2D &d) {
+    return MazeGenerators {
         new maze::AldousBroderMazeGenerator{d},
         new maze::BFSMazeGenerator{d},
         new maze::BinaryTreeMazeGenerator{d},
@@ -45,7 +45,7 @@ MazeGenerators createGenerators(const types::Dimensions2D &d) {
     };
 }
 
-void deleteGenerators(MazeGenerators &mgs) {
+void deleteMazeGenerators(MazeGenerators &mgs) {
     while (!mgs.empty()) {
         auto mg = mgs.back();
         mgs.pop_back();

--- a/src/test/maze/TestMazeSymmetries.cpp
+++ b/src/test/maze/TestMazeSymmetries.cpp
@@ -17,27 +17,24 @@
 
 using namespace spelunker;
 
-#include <iostream>
-using namespace std;
-
-TEST_CASE("Rectangular mazes can be manipulated via certain symmetries", "[maze][symmetry][rectangle]") {
+TEST_CASE("Rectangular Mazes can be manipulated via certain symmetries", "[maze][symmetry][rectangle]") {
     int constexpr width = 50;
     int constexpr height = 40;
     auto const dim = types::Dimensions2D{width, height};
 
     // Get all the generators and all the symmetries.
-    auto gens = createGenerators(dim);
+    auto gens = createMazeGenerators(dim);
     auto syms = types::symmetries();
 
     SECTION("All generators produce mazes of the correct size: " + typeclasses::Show<types::Dimensions2D>::show(dim)) {
         for (const auto gen: gens) {
-            const maze::Maze m = gen->generate();
+            const auto m = gen->generate();
             REQUIRE(m.getWidth() == width);
             REQUIRE(m.getHeight() == height);
         }
     }
 
-    SECTION("A maze under the action of two symmetries equals the maze under the action of their composition") {
+    SECTION("A Maze under the action of two symmetries equals the Maze under the action of their composition") {
         for (const auto s1: syms) {
             if (s1 == types::Symmetry::REFLECTION_IN_NESW || s1 == types::Symmetry::REFLECTION_IN_NWSE)
                 continue;
@@ -58,7 +55,7 @@ TEST_CASE("Rectangular mazes can be manipulated via certain symmetries", "[maze]
         }
     }
 
-    SECTION("Attempts to operate on a rectangular maze with diagonal symmetries should cause an exception") {
+    SECTION("Attempts to operate on a rectangular Maze with diagonal symmetries should cause an exception") {
         for (const auto s1: syms) {
             for (const auto s2: syms) {
                 const auto sc = types::composeSymmetries(s1, s2);
@@ -75,26 +72,26 @@ TEST_CASE("Rectangular mazes can be manipulated via certain symmetries", "[maze]
     }
 
     // Delete the generators.
-    deleteGenerators(gens);
+    deleteMazeGenerators(gens);
 }
 
-TEST_CASE("Square mazes can be manipulated via all symmetries", "[maze][symmetry][square]") {
+TEST_CASE("Square Mazes can be manipulated via all symmetries", "[maze][symmetry][square]") {
     int constexpr side = 50;
     auto const dim = types::Dimensions2D{side, side};
 
     // Get all the generators and all the symmetries.
-    auto gens = createGenerators(dim);
+    auto gens = createMazeGenerators(dim);
     auto syms = types::symmetries();
 
-    SECTION("All generators produce mazes of the correct size: " + typeclasses::Show<types::Dimensions2D>::show(dim)) {
+    SECTION("All generators produce Mazes of the correct size: " + typeclasses::Show<types::Dimensions2D>::show(dim)) {
         for (const auto gen: gens) {
-            const maze::Maze m = gen->generate();
+            const auto m = gen->generate();
             REQUIRE(m.getWidth() == side);
             REQUIRE(m.getHeight() == side);
         }
     }
 
-    SECTION("A maze under the action of two symmetries equals the maze under the action of their composition") {
+    SECTION("A Maze under the action of two symmetries equals the Maze under the action of their composition") {
         for (const auto s1: syms) {
             for (const auto s2: syms) {
                 const auto sc = types::composeSymmetries(s1, s2);
@@ -110,5 +107,5 @@ TEST_CASE("Square mazes can be manipulated via all symmetries", "[maze][symmetry
     }
 
     // Delete the generators.
-    deleteGenerators(gens);
+    deleteMazeGenerators(gens);
 }

--- a/src/test/maze/TestMazeSymmetries.cpp
+++ b/src/test/maze/TestMazeSymmetries.cpp
@@ -18,13 +18,13 @@
 using namespace spelunker;
 
 TEST_CASE("Rectangular Mazes can be manipulated via certain symmetries", "[maze][symmetry][rectangle]") {
-    int constexpr width = 50;
-    int constexpr height = 40;
-    auto const dim = types::Dimensions2D{width, height};
+    constexpr auto width = 50;
+    constexpr auto height = 40;
+    const auto dim = types::Dimensions2D{width, height};
 
     // Get all the generators and all the symmetries.
     auto gens = createMazeGenerators(dim);
-    auto syms = types::symmetries();
+    const auto syms = types::symmetries();
 
     SECTION("All generators produce mazes of the correct size: " + typeclasses::Show<types::Dimensions2D>::show(dim)) {
         for (const auto gen: gens) {
@@ -76,12 +76,12 @@ TEST_CASE("Rectangular Mazes can be manipulated via certain symmetries", "[maze]
 }
 
 TEST_CASE("Square Mazes can be manipulated via all symmetries", "[maze][symmetry][square]") {
-    int constexpr side = 50;
-    auto const dim = types::Dimensions2D{side, side};
+    constexpr auto side = 50;
+    const auto dim = types::Dimensions2D{side, side};
 
     // Get all the generators and all the symmetries.
     auto gens = createMazeGenerators(dim);
-    auto syms = types::symmetries();
+    const auto syms = types::symmetries();
 
     SECTION("All generators produce Mazes of the correct size: " + typeclasses::Show<types::Dimensions2D>::show(dim)) {
         for (const auto gen: gens) {

--- a/src/test/maze/TestRankPosition.cpp
+++ b/src/test/maze/TestRankPosition.cpp
@@ -1,0 +1,59 @@
+/**
+ * RankPositionTest.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Tests the @see{spelunker::maze::Maze::rankPositionS} function used by Mazes to
+ * map positions into WallIDs.
+ */
+
+#include <catch.hpp>
+
+#include <set>
+
+#include <types/CommonMazeAttributes.h>
+#include <types/Dimensions2D.h>
+#include <types/Direction.h>
+#include <maze/Maze.h>
+#include <maze/MazeAttributes.h>
+
+using namespace spelunker;
+
+TEST_CASE("Ranking walls for Maze representations", "[maze][rank]") {
+    constexpr auto width = 50;
+    constexpr auto height = 40;
+    const types::Dimensions2D dim{width, height};
+
+    std::set<int> ranks;
+    const auto numwalls = maze::calculateNumWalls(dim);
+
+    SECTION("Ranking walls from the position on either side of the wall yields the same rank") {
+        for (auto x = 0; x < width; ++x)
+            for (auto y = 0; y < height; ++y) {
+                for (auto dir: types::directions()) {
+                    const auto r = maze::Maze::rankPositionS(dim, x, y, dir);
+                    if (r != -1) ranks.insert(r);
+                }
+                if (y > 0 && y < height - 1)
+                    REQUIRE(maze::Maze::rankPositionS(dim, x, y, types::Direction::NORTH) ==
+                            maze::Maze::rankPositionS(dim, x, y - 1, types::Direction::SOUTH));
+                if (x > 0 && x < width - 1)
+                    REQUIRE(maze::Maze::rankPositionS(dim, x - 1, y, types::Direction::EAST) ==
+                            maze::Maze::rankPositionS(dim, x, y, types::Direction::WEST));
+            }
+    }
+
+    SECTION("For any wall rank, there is a position that ranks to it") {
+        for (auto x = 0; x < width; ++x)
+            for (auto y = 0; y < height; ++y) {
+                for (auto dir: types::directions()) {
+                    const auto r = maze::Maze::rankPositionS(dim, x, y, dir);
+                    if (r != -1) ranks.insert(r);
+                }
+            }
+
+        for (auto i = 0; i < numwalls; ++i)
+            REQUIRE(ranks.find(i) != ranks.end());
+
+    }
+}

--- a/src/test/maze/TestRankPosition.cpp
+++ b/src/test/maze/TestRankPosition.cpp
@@ -1,5 +1,5 @@
 /**
- * RankPositionTest.cpp
+ * TestRankPosition.cpp
  *
  * By Sebastian Raaphorst, 2018.
  *

--- a/src/test/maze/TestUnrankWallMap.cpp
+++ b/src/test/maze/TestUnrankWallMap.cpp
@@ -1,0 +1,40 @@
+/**
+ * TestUnrankWallMap.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Tests the @see{spelunker::maze::MazeGenerator::createUnrankWallMapS} function that
+ * unranks WallIds into pairs of positions.
+ */
+
+#include <catch.hpp>
+
+#include <types/Dimensions2D.h>
+#include <maze/Maze.h>
+#include <maze/MazeGenerator.h>
+
+using namespace spelunker;
+
+TEST_CASE("Unranking map from wall ranks to pairs of adjacent positions", "[maze][unrank]") {
+    constexpr auto width = 50;
+    constexpr auto height = 40;
+    const types::Dimensions2D dim{width, height};
+
+    const auto m = maze::MazeGenerator::createUnrankWallMapS(dim);
+
+    SECTION("The unranking wall map produces two positions, which both rank back to the wall id") {
+        for (const auto &kv : m) {
+            // kv is std::map<WallID, std::pair<types::Position, types::Position> >
+            const auto &[rk, ps] = kv;
+            const auto &[p1, p2] = ps;
+
+            const auto &[c1, d1] = p1;
+            const auto[x1, y1] = c1;
+            REQUIRE(maze::Maze::rankPositionS(dim, x1, y1, d1) == rk);
+
+            const auto &[c2, d2] = p2;
+            const auto[x2, y2] = c2;
+            REQUIRE(maze::Maze::rankPositionS(dim, x2, y2, d2) == rk);
+        }
+    }
+}

--- a/src/test/thickmaze/TestThickMazeSymmetries.cpp
+++ b/src/test/thickmaze/TestThickMazeSymmetries.cpp
@@ -19,8 +19,8 @@ using namespace spelunker;
 
 
 TEST_CASE("Rectangular ThickMazes can be manipulated via certain symmetries", "[thickmaze][symmetry][rectangle]") {
-    int constexpr width = 50;
-    int constexpr height = 40;
+    constexpr auto width = 50;
+    constexpr auto height = 40;
     const auto dim = types::Dimensions2D{width, height};
 
     // ThickMaze constructions from regular mazes produce size 2w-1 by 2h-1.
@@ -28,15 +28,17 @@ TEST_CASE("Rectangular ThickMazes can be manipulated via certain symmetries", "[
 
     // Get all the generators and all the symmetries.
     auto gens = createThickMazeGenerators(dim);
-    auto syms = types::symmetries();
+    const auto syms = types::symmetries();
 
     SECTION("All generators produce ThickMazes of the correct size: " +
             typeclasses::Show<types::Dimensions2D>::show(dim) + " or " +
             typeclasses::Show<types::Dimensions2D>::show(dim_1)) {
         for (const auto gen: gens) {
             const auto m = gen->generate();
-            REQUIRE(m.getWidth() == Approx(width).epsilon(1));
-            REQUIRE(m.getHeight() == Approx(width).epsilon(1));
+
+            // Use approx to allow width / height or width - 1 / height - 1 (for the hommorphism constructions).
+            REQUIRE(m.getWidth() == Approx(width - 0.5).epsilon(0.5));
+            REQUIRE(m.getHeight() == Approx(height - 0.5).epsilon(0.5));
         }
     }
 
@@ -82,23 +84,25 @@ TEST_CASE("Rectangular ThickMazes can be manipulated via certain symmetries", "[
 }
 
 TEST_CASE("Square ThickMazes can be manipulated via all symmetries", "[thickmaze][symmetry][square]") {
-    int constexpr side = 50;
-    auto const dim = types::Dimensions2D{side, side};
+    constexpr auto side = 50;
+    const auto dim = types::Dimensions2D{side, side};
 
     // ThickMaze constructions from regular mazes produce size 2w-1 by 2h-1.
-    auto const dim_1 = types::Dimensions2D{side-1, side-1};
+    const auto dim_1 = types::Dimensions2D{side-1, side-1};
 
     // Get all the generators and all the symmetries.
     auto gens = createThickMazeGenerators(dim);
-    auto syms = types::symmetries();
+    const auto syms = types::symmetries();
 
     SECTION("All generators produce ThickMazes of the correct size: " +
             typeclasses::Show<types::Dimensions2D>::show(dim) + " or " +
             typeclasses::Show<types::Dimensions2D>::show(dim_1)) {
         for (const auto gen: gens) {
             const auto m = gen->generate();
-            REQUIRE(m.getWidth() == Approx(side).epsilon(1));
-            REQUIRE(m.getHeight() == Approx(side).epsilon(1));
+
+            // Use approx to allow width / height or width - 1 / height - 1 (for the hommorphism constructions).
+            REQUIRE(m.getWidth()  == Approx(side - 0.5).epsilon(0.5));
+            REQUIRE(m.getHeight() == Approx(side - 0.5).epsilon(0.5));
         }
     }
 

--- a/src/test/thickmaze/TestThickMazeSymmetries.cpp
+++ b/src/test/thickmaze/TestThickMazeSymmetries.cpp
@@ -6,3 +6,117 @@
 
 #include <catch.hpp>
 
+#include <string>
+
+#include <types/Dimensions2D.h>
+#include <types/Symmetry.h>
+#include <typeclasses/Show.h>
+#include <thickmaze/ThickMaze.h>
+#include <thickmaze/ThickMazeGenerator.h>
+#include "ThickMazeGenerators.h"
+
+using namespace spelunker;
+
+
+TEST_CASE("Rectangular ThickMazes can be manipulated via certain symmetries", "[thickmaze][symmetry][rectangle]") {
+    int constexpr width = 50;
+    int constexpr height = 40;
+    const auto dim = types::Dimensions2D{width, height};
+
+    // ThickMaze constructions from regular mazes produce size 2w-1 by 2h-1.
+    const auto dim_1 = types::Dimensions2D{width-1, height-1};
+
+    // Get all the generators and all the symmetries.
+    auto gens = createThickMazeGenerators(dim);
+    auto syms = types::symmetries();
+
+    SECTION("All generators produce ThickMazes of the correct size: " +
+            typeclasses::Show<types::Dimensions2D>::show(dim) + " or " +
+            typeclasses::Show<types::Dimensions2D>::show(dim_1)) {
+        for (const auto gen: gens) {
+            const auto m = gen->generate();
+            REQUIRE(m.getWidth() == Approx(width).epsilon(1));
+            REQUIRE(m.getHeight() == Approx(width).epsilon(1));
+        }
+    }
+
+    SECTION("A ThickMaze under the action of two symmetries equals the ThickMaze under the action of their composition") {
+        for (const auto s1: syms) {
+            if (s1 == types::Symmetry::REFLECTION_IN_NESW || s1 == types::Symmetry::REFLECTION_IN_NWSE)
+                continue;
+            for (const auto s2: syms) {
+                if (s2 == types::Symmetry::REFLECTION_IN_NESW || s2 == types::Symmetry::REFLECTION_IN_NWSE)
+                    continue;
+                const auto sc = types::composeSymmetries(s1, s2);
+                if (sc == types::Symmetry::REFLECTION_IN_NESW || sc == types::Symmetry::REFLECTION_IN_NWSE)
+                    continue;
+
+                for (const auto gen: gens) {
+                    const auto m = gen->generate();
+                    const auto ms = m.applySymmetry(s1).applySymmetry(s2);
+                    const auto mc = m.applySymmetry(sc);
+                    REQUIRE(ms == mc);
+                }
+            }
+        }
+    }
+
+    SECTION("Attempts to operate on a rectangular ThickMaze with diagonal symmetries should cause an exception") {
+        for (const auto s1: syms) {
+            for (const auto s2: syms) {
+                const auto sc = types::composeSymmetries(s1, s2);
+                if (s1 != types::Symmetry::REFLECTION_IN_NESW && s1 != types::Symmetry::REFLECTION_IN_NWSE &&
+                    s2 != types::Symmetry::REFLECTION_IN_NESW && s2 != types::Symmetry::REFLECTION_IN_NWSE &&
+                    sc != types::Symmetry::REFLECTION_IN_NESW && sc != types::Symmetry::REFLECTION_IN_NWSE)
+                    continue;
+                for (const auto gen: gens) {
+                    const auto m = gen->generate();
+                    REQUIRE_THROWS(m.applySymmetry(s1).applySymmetry(s2) == m.applySymmetry(sc));
+                }
+            }
+        }
+    }
+
+    // Delete the generators.
+    deleteThickMazeGenerators(gens);
+}
+
+TEST_CASE("Square ThickMazes can be manipulated via all symmetries", "[thickmaze][symmetry][square]") {
+    int constexpr side = 50;
+    auto const dim = types::Dimensions2D{side, side};
+
+    // ThickMaze constructions from regular mazes produce size 2w-1 by 2h-1.
+    auto const dim_1 = types::Dimensions2D{side-1, side-1};
+
+    // Get all the generators and all the symmetries.
+    auto gens = createThickMazeGenerators(dim);
+    auto syms = types::symmetries();
+
+    SECTION("All generators produce ThickMazes of the correct size: " +
+            typeclasses::Show<types::Dimensions2D>::show(dim) + " or " +
+            typeclasses::Show<types::Dimensions2D>::show(dim_1)) {
+        for (const auto gen: gens) {
+            const auto m = gen->generate();
+            REQUIRE(m.getWidth() == Approx(side).epsilon(1));
+            REQUIRE(m.getHeight() == Approx(side).epsilon(1));
+        }
+    }
+
+    SECTION("A ThickMaze under the action of two symmetries equals the ThickMaze under the action of their composition") {
+        for (const auto s1: syms) {
+            for (const auto s2: syms) {
+                const auto sc = types::composeSymmetries(s1, s2);
+
+                for (const auto gen: gens) {
+                    const auto m = gen->generate();
+                    const auto ms = m.applySymmetry(s1).applySymmetry(s2);
+                    const auto mc = m.applySymmetry(sc);
+                    REQUIRE(ms == mc);
+                }
+            }
+        }
+    }
+
+    // Delete the generators.
+    deleteThickMazeGenerators(gens);
+}

--- a/src/test/thickmaze/ThickMazeGenerators.h
+++ b/src/test/thickmaze/ThickMazeGenerators.h
@@ -1,0 +1,67 @@
+/**
+ * ThickMazeGenerators.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <types/Dimensions2D.h>
+#include <maze/MazeGenerator.h>
+#include <maze/AldousBroderMazeGenerator.h>
+#include <maze/BFSMazeGenerator.h>
+#include <maze/BinaryTreeMazeGenerator.h>
+#include <maze/DFSMazeGenerator.h>
+#include <maze/EllerMazeGenerator.h>
+#include <maze/GrowingTreeMazeGenerator.h>
+#include <maze/HuntAndKillMazeGenerator.h>
+#include <maze/KruskalMazeGenerator.h>
+#include <maze/PrimMazeGenerator.h>
+#include <maze/Prim2MazeGenerator.h>
+#include <maze/RecursiveDivisionMazeGenerator.h>
+#include <maze/SidewinderMazeGenerator.h>
+#include <maze/WilsonMazeGenerator.h>
+#include <thickmaze/ThickMazeGenerator.h>
+#include <thickmaze/ThickMazeGeneratorByHomomorphism.h>
+#include <thickmaze/CellularAutomatonThickMazeGenerator.h>
+#include <thickmaze/GridColouring.h>
+#include <thickmaze/GridColouringThickMazeGenerator.h>
+#include <math/RNG.h>
+using namespace spelunker;
+
+// Return a list of all TihickMazeGenerators.
+using ThickMazeGenerators = std::vector<thickmaze::ThickMazeGenerator*>;
+
+ThickMazeGenerators createThickMazeGenerators(const types::Dimensions2D &d) {
+    const types::Dimensions2D dhalf = d/2;
+    const thickmaze::GridColouring gridColouring{4, 1, 2};
+    const thickmaze::GridColouring::CandidateConfigurationCollection cfgColl = gridColouring.wallCandidates(10);
+    const thickmaze::GridColouring::CandidateConfiguration cfg = math::RNG::randomElement(cfgColl);
+
+    return ThickMazeGenerators {
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::AldousBroderMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::BFSMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::BinaryTreeMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::EllerMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::GrowingTreeMazeGenerator{dhalf, maze::GrowingTreeMazeGenerator::CellSelectionStrategy::RANDOM}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::HuntAndKillMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::KruskalMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::PrimMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::Prim2MazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::RecursiveDivisionMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::SidewinderMazeGenerator{dhalf}},
+        new thickmaze::ThickMazeGeneratorByHomomorphism{new maze::WilsonMazeGenerator{dhalf}},
+        new thickmaze::CellularAutomatonThickMazeGenerator{d, thickmaze::CellularAutomatonThickMazeGenerator::settings{}},
+        new thickmaze::GridColouringThickMazeGenerator{d, gridColouring, cfg}
+    };
+}
+
+void deleteThickMazeGenerators(ThickMazeGenerators &mgs) {
+    while (!mgs.empty()) {
+        auto mg = mgs.back();
+        mgs.pop_back();
+        delete mg;
+    }
+}

--- a/src/test/thickmaze/ThickMazeGenerators.h
+++ b/src/test/thickmaze/ThickMazeGenerators.h
@@ -34,7 +34,7 @@ using namespace spelunker;
 // Return a list of all TihickMazeGenerators.
 using ThickMazeGenerators = std::vector<thickmaze::ThickMazeGenerator*>;
 
-ThickMazeGenerators createThickMazeGenerators(const types::Dimensions2D &d) {
+const ThickMazeGenerators createThickMazeGenerators(const types::Dimensions2D &d) {
     const types::Dimensions2D dhalf = d/2;
     const thickmaze::GridColouring gridColouring{4, 1, 2};
     const thickmaze::GridColouring::CandidateConfigurationCollection cfgColl = gridColouring.wallCandidates(10);

--- a/src/thickmaze/CMakeLists.txt
+++ b/src/thickmaze/CMakeLists.txt
@@ -9,6 +9,7 @@ set(_THICKMAZE_PUBLIC_HEADER_FILES
         ThickMaze.h
         ThickMazeAttributes.h
         ThickMazeGenerator.h
+        ThickMazeGeneratorByHomomorphism.h
         ThickMazeRenderer.h
         ThickMazeTypeclasses.h
         PARENT_SCOPE
@@ -26,6 +27,7 @@ set(_THICKMAZE_SOURCE_FILES
         ThickMaze.cpp
         ThickMazeAttributes.cpp
         ThickMazeGenerator.cpp
+        ThickMazeGeneratorByHomomorphism.cpp
         PARENT_SCOPE
         )
 

--- a/src/thickmaze/CellularAutomatonThickMazeGenerator.h
+++ b/src/thickmaze/CellularAutomatonThickMazeGenerator.h
@@ -42,7 +42,7 @@ namespace spelunker::thickmaze {
      * Note that these algorithms sometimes do better if the resultant mazes are reversed via a call
      * to @see{ThickMaze#reverse}.
      */
-    class CellularAutomatonThickMazeGenerator final : ThickMazeGenerator {
+    class CellularAutomatonThickMazeGenerator final : public ThickMazeGenerator {
     public:
         /// A function type that determines the number of living neighbours.
         using NeighbourCounter = std::function<int(const types::Cell, const CellContents&)>;

--- a/src/thickmaze/GridColouringThickMazeGenerator.h
+++ b/src/thickmaze/GridColouringThickMazeGenerator.h
@@ -23,7 +23,7 @@
 namespace spelunker::thickmaze {
     class ThickMaze;
 
-    class GridColouringThickMazeGenerator final : ThickMazeGenerator {
+    class GridColouringThickMazeGenerator final : public ThickMazeGenerator {
     public:
         GridColouringThickMazeGenerator(const types::Dimensions2D &d,
                                         const GridColouring &gc, const GridColouring::CandidateConfiguration &cfg);

--- a/src/thickmaze/ThickMazeGeneratorByHomomorphism.cpp
+++ b/src/thickmaze/ThickMazeGeneratorByHomomorphism.cpp
@@ -1,0 +1,29 @@
+/**
+ * ThickMazeGeneratorByHomomorphism.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <types/Dimensions2D.h>
+#include <typeclasses/Homomorphism.h>
+#include <maze/Maze.h>
+#include <maze/MazeGenerator.h>
+#include <maze/MazeTypeclasses.h>
+
+#include "ThickMaze.h"
+#include "ThickMazeGeneratorByHomomorphism.h"
+
+namespace spelunker::thickmaze {
+    ThickMazeGeneratorByHomomorphism::ThickMazeGeneratorByHomomorphism(const maze::MazeGenerator *mg)
+        : ThickMazeGenerator{types::Dimensions2D{2 * mg->getWidth() - 1, 2 * mg->getHeight() - 1}}, mazeGenerator{mg} {}
+
+    ThickMazeGeneratorByHomomorphism::~ThickMazeGeneratorByHomomorphism() {
+        delete mazeGenerator;
+    }
+
+    const ThickMaze ThickMazeGeneratorByHomomorphism::generate() const noexcept {
+        const maze::Maze m = mazeGenerator->generate();
+        const ThickMaze tm = typeclasses::Homomorphism<maze::Maze, ThickMaze>::morph(m);
+        return tm;
+    }
+}

--- a/src/thickmaze/ThickMazeGeneratorByHomomorphism.h
+++ b/src/thickmaze/ThickMazeGeneratorByHomomorphism.h
@@ -1,0 +1,35 @@
+/**
+ * ThickMazeGeneratorByHomomorphism.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#pragma once
+
+#include <maze/MazeGenerator.h>
+#include "ThickMazeGenerator.h"
+
+namespace spelunker::thickmaze {
+    /**
+     * This class takes a generator for a regular Maze and, via the homomorphism
+     * from Maze to ThickMaze, wraps it and makes it into a generator for ThickMaze.
+     * Note that the object takes ownership of the pointer passed in, and deletes it
+     * when this object is deleted.
+     */
+    class ThickMazeGeneratorByHomomorphism final : public ThickMazeGenerator {
+    public:
+        /**
+         * The constructor takes a MazeGenerator, and then, since the homomorphism
+         * from Maze to ThickMaze results in a ThickMaze that is twice the width
+         * and twice the height of the original, sets these parameters as such.
+         * @param mg the MazeGenerator to wrap
+         */
+        ThickMazeGeneratorByHomomorphism(const maze::MazeGenerator *mg);
+        ~ThickMazeGeneratorByHomomorphism() override;
+
+        const ThickMaze generate() const noexcept override;
+
+    private:
+        const maze::MazeGenerator *mazeGenerator;
+    };
+}

--- a/src/types/Dimensions2D.cpp
+++ b/src/types/Dimensions2D.cpp
@@ -18,6 +18,18 @@ namespace spelunker::types {
         return width == other.getWidth() && height == other.getHeight();
     }
 
+    Dimensions2D Dimensions2D::operator+(const Dimensions2D &other) const noexcept {
+        return Dimensions2D{width + other.getWidth(), height + other.getHeight()};
+    }
+
+    Dimensions2D Dimensions2D::operator*(const int scalar) const noexcept {
+        return Dimensions2D{scalar * width, scalar * height};
+    }
+
+    Dimensions2D Dimensions2D::operator/(int scalar) const {
+        return Dimensions2D{width / scalar, height / scalar};
+    }
+
     bool Dimensions2D::cellInBounds(const int x, const int y) const noexcept {
         return x >= 0 && x < width && y >= 0 && y < height;
     }

--- a/src/types/Dimensions2D.h
+++ b/src/types/Dimensions2D.h
@@ -30,6 +30,15 @@ namespace spelunker::types {
         /// Determine if two dimensions objects are the same.
         bool operator==(const Dimensions2D &other) const noexcept;
 
+        /// Add two dimensions together.
+        Dimensions2D operator+(const Dimensions2D &other) const noexcept;
+
+        /// Multiply by a scalar.
+        Dimensions2D operator*(int scalar) const noexcept;
+
+        // Divide by a scalar (integer division).
+        Dimensions2D operator/(int scalar) const;
+
         /// Get the width part of the dimensions.
         inline int getWidth() const noexcept {
             return width;
@@ -84,6 +93,10 @@ namespace spelunker::types {
         const int width;
         const int height;
     };
+
+    inline Dimensions2D operator*(int scalar, const Dimensions2D dim) noexcept {
+        return dim.operator*(scalar);
+    }
 }
 
 namespace spelunker::typeclasses {


### PR DESCRIPTION
This PR does the following:

1. Creates a new subclass of `ThickMazeGenerator`, namely `ThickMazeGeneratorByHomomorphism`, which takes in a pointer to a `MazeGenerator` and can then use the `MazeGenerator` via the `Homomorphism<Maze, ThickMaze>` to produce `ThickMaze`s without having to explicitly call the `Homomorphism`.
2. Adds test cases to test the effects of applying `Symmetry` transformations to `ThickMaze`s.
3. Extracts the wall ranking test code out of `Maze`, which checks that both `Position`s on either side of a wall rank to the same `WallID`, and that for every `WallID`, some `Position` ranks to it.
4. Extracts the wall unranking test code out of `MazeGenerator`, which checks that a `WallID` unranks into two `Positions`, both of which rank back to the same `WallID`.
5. Adds some operators to `Dimensions2D` to make it easier to work with.
6. Comprises general cleanup.