### PR TITLE
T2: Fixed Dimensions2D / IllegalDimensions bug.

### DIFF
--- a/src/test/types/TestDimensions2D.cpp
+++ b/src/test/types/TestDimensions2D.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Dimensions2D should have overloaded operators", "[types][dimensions][
     }
 }
 
-TEST_CASE("Dimensions should be able to tell if a cell is in bounds", "[types][dimensions]") {
+TEST_CASE("Dimensions should be able to tell if a cell is in bounds", "[types][dimensions][exception]") {
     const types::Dimensions2D dim{width, height};
 
     SECTION("Points in bounds should be recognized as such") {
@@ -113,14 +113,12 @@ TEST_CASE("Dimensions should know if they are square", "[types][dimensions][squa
         for (auto y=0; y < height; ++y)
             REQUIRE(types::Dimensions2D{x, y}.isSquare() == (x == y));
 }
-/**
- * These cause an EXC_BAD_ACCESS on MacOS X, so just say no.
- */
-//TEST_CASE("Dimensions2D should not allow negative values", "[types][dimensions][illegal]") {
-//    SECTION("Width cannot be -1") {
-//        REQUIRE_THROWS(types::Dimensions2D{-1, height});
-//    }
-//    SECTION("Height cannot be -1") {
-//        REQUIRE_THROWS(types::Dimensions2D{width, -1});
-//    }
-//}
+
+TEST_CASE("Dimensions2D should not allow negative values", "[types][dimensions][exception]") {
+    SECTION("Width cannot be -1") {
+        REQUIRE_THROWS(types::Dimensions2D{-1, height});
+    }
+    SECTION("Height cannot be -1") {
+        REQUIRE_THROWS(types::Dimensions2D{width, -1});
+    }
+}

--- a/src/types/AbstractMaze.h
+++ b/src/types/AbstractMaze.h
@@ -26,7 +26,7 @@ namespace spelunker::types {
         AbstractMaze(const Dimensions2D &d, const PossibleCell &startPos, const CellCollection &endPos)
             : dimensions{d}, startCell{startPos}, goalCells{endPos} {
             if (d.getWidth() < 1 || d.getHeight() < 1)
-                throw types::IllegalDimensions(d);
+                throw types::IllegalDimensions(d.getWidth(), d.getHeight());
             if (startCell)
                 checkCell(*startCell);
             for (const auto g: goalCells)

--- a/src/types/Dimensions2D.cpp
+++ b/src/types/Dimensions2D.cpp
@@ -16,7 +16,7 @@ namespace spelunker::types {
     Dimensions2D::Dimensions2D(int w, int h)
         : width{w}, height{h} {
         if (w < 0 || h < 0)
-            throw new IllegalDimensions(w, h);
+            throw IllegalDimensions(w, h);
     }
 
     bool Dimensions2D::operator==(const Dimensions2D &other) const noexcept {

--- a/src/types/Exceptions.h
+++ b/src/types/Exceptions.h
@@ -13,7 +13,7 @@
 #include <maze/MazeAttributes.h>
 #include <typeclasses/Show.h>
 
-#include "Dimensions2D.h"
+//#include "Dimensions2D.h"
 #include "Symmetry.h"
 
 namespace spelunker::types {
@@ -40,13 +40,12 @@ namespace spelunker::types {
     /// Thrown if the user tries to create a maze with illegal dimensions.
     class IllegalDimensions : public Exception {
     public:
-        IllegalDimensions(const Dimensions2D &d) : Exception(msg(d)) {}
-        IllegalDimensions(const int width, const int height) : Exception(msg(Dimensions2D{width, height})) {}
+        IllegalDimensions(const int width, const int height) : Exception(msg(std::make_pair(width, height))) {}
 
     private:
-        static std::string msg(const Dimensions2D &d) {
+        static std::string msg(const std::pair<int, int> &d) {
             return "Dimensions2D "
-                   + typeclasses::Show<Dimensions2D>::show(d)
+                   + typeclasses::Show<std::pair<int,int>>::show(d)
                    + " are not legal.";
         }
     };


### PR DESCRIPTION
Fixed a completely stupid bug where, when a `Dimensions2D` was illegal, I threw an `IllegalDimensions` object, which tries to create the illegal `Dimensions2D` object again, resulting in an `EXC_BAD_ACCESS`.