### PR TITLE
T2: Removed rest of std::optional.

### DIFF
--- a/src/graphmaze/GraphMazeAttributes.h
+++ b/src/graphmaze/GraphMazeAttributes.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
-#include <optional>
+// We use Boost optional instead of STL optional for serialization purposes.
+#include <boost/optional.hpp>
+
 #include <tuple>
 #include <vector>
 
@@ -22,7 +24,7 @@ namespace spelunker::graphmaze {
     using VertexCell = int;
 
     /// A possible cell, used to represent, for example, the start vertex.
-    using PossibleVertexCell = std::optional<VertexCell>;
+    using PossibleVertexCell = boost::optional<VertexCell>;
 
     /// A collection or row of VertexCells.
     using VertexCellCollection = std::vector<VertexCell>;

--- a/src/maze/Maze.cpp
+++ b/src/maze/Maze.cpp
@@ -8,13 +8,7 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 
-#include <cassert>
 #include <functional>
-#include <map>
-#include <optional>
-#include <set>
-#include <stdexcept>
-#include <tuple>
 #include <vector>
 
 #include <math/MathUtils.h>

--- a/src/thickmaze/GridColouringThickMazeGenerator.cpp
+++ b/src/thickmaze/GridColouringThickMazeGenerator.cpp
@@ -4,9 +4,11 @@
  * By Sebastian Raaphorst, 2018.
  */
 
+// We use Boost optional instead of STL optional for serialization purposes.
+#include <boost/optional.hpp>
+
 #include <algorithm>
 #include <cassert>
-#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -172,7 +174,7 @@ namespace spelunker::thickmaze {
         return ThickMaze(width, height, contents);
     }
 
-    std::optional<GridColouringThickMazeGenerator::AggregateWall>
+    boost::optional<GridColouringThickMazeGenerator::AggregateWall>
             GridColouringThickMazeGenerator::offsetToAggregate(const types::Cell &c, const GridColouring::Offsets &offsets) const {
         AggregateWall wall;
 

--- a/src/thickmaze/GridColouringThickMazeGenerator.h
+++ b/src/thickmaze/GridColouringThickMazeGenerator.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
-#include <optional>
+// We use Boost optional instead of STL optional for serialization purposes.
+#include <boost/optional.hpp>
+
 #include <tuple>
 #include <vector>
 
@@ -47,7 +49,7 @@ namespace spelunker::thickmaze {
          * @param offsets the offsets to apply to the positions
          * @return the concrete positions if they exist, and nothing otherwise
          */
-        std::optional<AggregateWall> offsetToAggregate(const types::Cell &c, const GridColouring::Offsets &offsets) const;
+        boost::optional<AggregateWall> offsetToAggregate(const types::Cell &c, const GridColouring::Offsets &offsets) const;
 
         /**
          * Given an aggregate wall, find the one or two rooms that it connects.


### PR DESCRIPTION
Replaced by `boost::optional` since this works naturally with Boost.Serialization.