### PR TITLE
T94: ThickMaze start / goal positions

### DIFF
--- a/apps/cellular_automaton.cpp
+++ b/apps/cellular_automaton.cpp
@@ -17,8 +17,8 @@ using namespace spelunker::thickmaze;
 
 int main(int argc, char *argv[]) {
     CellularAutomatonThickMazeGenerator::settings s{};
-    CellularAutomatonThickMazeGenerator gen(100, 50, s);
-    ThickMaze tm = gen.generate();//.reverse();
+    CellularAutomatonThickMazeGenerator gen{100, 50, s};
+    ThickMaze tm = gen.generate();
     std::cout << spelunker::typeclasses::Show<spelunker::thickmaze::ThickMaze>::show(tm);
     return 0;
 }

--- a/src/test/thickmaze/TestThickMaze.cpp
+++ b/src/test/thickmaze/TestThickMaze.cpp
@@ -8,11 +8,16 @@
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <sstream>
 
+#include <types/CommonMazeAttributes.h>
 #include <types/Dimensions2D.h>
 #include <maze/DFSMazeGenerator.h>
+#include <thickmaze/CellularAutomatonThickMazeGenerator.h>
 #include <thickmaze/ThickMaze.h>
+#include <thickmaze/ThickMazeAttributes.h>
 #include <thickmaze/ThickMazeGeneratorByHomomorphism.h>
 
 using namespace spelunker;
@@ -40,4 +45,52 @@ TEST_CASE("ThicMaze should be able to serialize and deserialize", "[thickmaze][s
     REQUIRE(tm1 == tml1);
     REQUIRE(tm2 == tml2);
     REQUIRE(tml1 != tml2);
+}
+
+TEST_CASE("ThickMaze should obey the rules of reversiblity") {
+    constexpr auto width = 100;
+    constexpr auto height = 50;
+
+    thickmaze::CellularAutomatonThickMazeGenerator gen{width, height};
+    auto tm = gen.generate();
+
+    SECTION("Reverse on a maze with no start or goals should be an order 2 operation") {
+        const auto tmr = tm.reverse();
+        REQUIRE(tm != tmr);
+
+        const auto tmrr = tmr.reverse();
+        REQUIRE(tm == tmrr);
+    }
+
+    SECTION("Reverse should eliminate start positions and goals") {
+        constexpr auto maxSpecialCells = 4;
+
+        // Just find a start cell and two empty goal cells.
+        types::CellCollection goals;
+
+        auto num = 0;
+        for (auto x = 0; x < width && num < maxSpecialCells; ++x) {
+            for (auto y = 0; y < height && num < maxSpecialCells; ++y) {
+                if (tm.cellIs(x, y) == thickmaze::CellType::FLOOR) {
+                    if (num == 0) {
+                        tm.setStartingCell(types::cell(x, y));
+                        ++num;
+                    } else {
+                        goals.emplace_back(types::cell(x, y));
+                        ++num;
+                    }
+                }
+            }
+        }
+        tm.setGoalCells(goals);
+
+        // These may not appear to be best practices, but getting Catch2 to compile
+        // with boost::optional was not easy; hence the reliance on the deprecated method.
+        REQUIRE(tm.getStartingCell().is_initialized());
+        REQUIRE(tm.getGoalCells().size() > 0);
+        const thickmaze::ThickMaze tmr = tm.reverse();
+        REQUIRE_FALSE(tmr.getStartingCell().is_initialized());
+        REQUIRE(tmr.getGoalCells().empty());
+    }
+
 }

--- a/src/thickmaze/CellularAutomatonThickMazeGenerator.cpp
+++ b/src/thickmaze/CellularAutomatonThickMazeGenerator.cpp
@@ -140,8 +140,14 @@ namespace spelunker::thickmaze {
     CellularAutomatonThickMazeGenerator::CellularAutomatonThickMazeGenerator(const types::Dimensions2D &d, const settings &s)
         : ThickMazeGenerator{d}, st{s} {}
 
+    CellularAutomatonThickMazeGenerator::CellularAutomatonThickMazeGenerator(const types::Dimensions2D &d)
+        : CellularAutomatonThickMazeGenerator{d, settings{}} {}
+
     CellularAutomatonThickMazeGenerator::CellularAutomatonThickMazeGenerator(int w, int h, const settings &s)
         : CellularAutomatonThickMazeGenerator{types::Dimensions2D{w, h}, s} {}
+
+    CellularAutomatonThickMazeGenerator::CellularAutomatonThickMazeGenerator(int w, int h)
+        : CellularAutomatonThickMazeGenerator{types::Dimensions2D{w, h}, settings{}} {}
 
     const ThickMaze CellularAutomatonThickMazeGenerator::generate() const noexcept {
         const auto [width, height] = getDimensions().values();

--- a/src/thickmaze/CellularAutomatonThickMazeGenerator.h
+++ b/src/thickmaze/CellularAutomatonThickMazeGenerator.h
@@ -132,7 +132,9 @@ namespace spelunker::thickmaze {
         };
 
         CellularAutomatonThickMazeGenerator(const types::Dimensions2D &d, const settings &s);
+        CellularAutomatonThickMazeGenerator(const types::Dimensions2D &d);
         CellularAutomatonThickMazeGenerator(int w, int h, const settings &s);
+        CellularAutomatonThickMazeGenerator(int w, int h);
         ~CellularAutomatonThickMazeGenerator() final = default;
 
         const ThickMaze generate() const noexcept final;

--- a/src/thickmaze/ThickMaze.cpp
+++ b/src/thickmaze/ThickMaze.cpp
@@ -25,7 +25,15 @@ namespace spelunker::thickmaze {
                          const types::PossibleCell &start,
                          const types::CellCollection &goals,
                          const CellContents &c)
-        : types::AbstractMaze<ThickMaze>{d, start, goals}, contents{c} {}
+        : types::AbstractMaze<ThickMaze>{d, start, goals}, contents{c} {
+
+        if (start && cellIs(*start) == CellType::WALL)
+            throw types::IllegalCellPosition{*start, types::SpecialCellType::START};
+
+        for (auto gc: goals)
+            if (cellIs(gc) == CellType::WALL)
+                throw types::IllegalCellPosition{gc, types::SpecialCellType::GOAL};
+    }
 
     ThickMaze::ThickMaze(const types::Dimensions2D &d, const thickmaze::CellContents &c)
         : ThickMaze{d, {}, types::CellCollection(), c} {}
@@ -49,6 +57,11 @@ namespace spelunker::thickmaze {
     const CellType ThickMaze::cellIs(int x, int y) const {
         checkCell(x, y);
         return contents[x][y];
+    }
+
+    const CellType ThickMaze::cellIs(const spelunker::types::Cell &c) const {
+        const auto [x, y] = c;
+        return cellIs(x, y);
     }
 
     int ThickMaze::numCellWalls(const types::Cell &c) const {

--- a/src/thickmaze/ThickMaze.cpp
+++ b/src/thickmaze/ThickMaze.cpp
@@ -133,7 +133,7 @@ namespace spelunker::thickmaze {
         for (auto y=0; y < height; ++y)
             for (auto x=0; x < width; ++x)
                 invContents[x][y] = contents[x][y] == CellType::FLOOR ?CellType::WALL : CellType::FLOOR;
-        return ThickMaze(getDimensions(), invContents);
+        return ThickMaze{getDimensions(), invContents};
     }
 
     const ThickMaze ThickMaze::braid(double probability) const noexcept {

--- a/src/thickmaze/ThickMaze.h
+++ b/src/thickmaze/ThickMaze.h
@@ -12,6 +12,7 @@
 
 #include <types/AbstractMaze.h>
 #include <types/Dimensions2D.h>
+#include <types/ReversibleMaze.h>
 #include <types/Symmetry.h>
 
 #include "ThickMazeAttributes.h"
@@ -29,7 +30,7 @@ namespace spelunker::thickmaze {
      * odd width and height where walls are all contiguous cells of odd length >= 3. The mapping to this subset
      * is surjective, and thus Mazes and ThickMazes with this property are isomorphic.
      */
-    class ThickMaze : public types::AbstractMaze<ThickMaze> {
+    class ThickMaze : public types::AbstractMaze<ThickMaze>, public types::ReversibleMaze<ThickMaze> {
     public:
         /**
          * Create a ThickMaze with the given dimensions, start position, goal positions,
@@ -82,7 +83,10 @@ namespace spelunker::thickmaze {
         bool operator!=(const ThickMaze &other) const noexcept {
             return !(*this == other);
         }
+
         const CellType cellIs(int x, int y) const;
+
+        const CellType cellIs(const types::Cell &c) const;
 
         /// Determine the number of walls a cell has.
         int numCellWalls(const types::Cell &c) const override;
@@ -95,7 +99,7 @@ namespace spelunker::thickmaze {
          * cellular automata algorithms, which are sometimes more wall-connected than floor-connected.
          * @return the reverse of the original maze, with walls and floors swapper.
          */
-        const ThickMaze reverse() const noexcept;
+        const ThickMaze reverse() const noexcept override;
 
         /// Make a ThickMaze into a braid maze, clearing dead ends with the given probability.
         /**

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -8,6 +8,7 @@ set(_TYPES_PUBLIC_HEADER_FILES
         Dimensions2D.h
         Direction.h
         Exceptions.h
+        ReversibleMaze.h
         Symmetry.h
         UnicursalizableMaze.h
         PARENT_SCOPE

--- a/src/types/CommonMazeAttributes.cpp
+++ b/src/types/CommonMazeAttributes.cpp
@@ -34,4 +34,13 @@ namespace spelunker::types {
         const auto [width, height] = d.values();
         return CellIndicator(width, CellRowIndicator(height, def));
     }
+
+    std::string specialCellTypeName(const SpecialCellType c) {
+        switch (c) {
+            case SpecialCellType::START:
+                return "start";
+            case SpecialCellType::GOAL:
+                return "goal";
+        }
+    }
 }

--- a/src/types/CommonMazeAttributes.h
+++ b/src/types/CommonMazeAttributes.h
@@ -92,4 +92,13 @@ namespace spelunker::types {
      * @return a Position representing the Cell and the Direction
      */
     inline Position pos(const Cell &c, Direction d) { return std::make_pair(c, d); }
+
+    /// An enumeration to specify the types of special cells in a maze.
+    enum class SpecialCellType {
+        START = 0,
+        GOAL,
+    };
+
+    /// Represent a @see{SpecialCellType} by a descriptive string.
+    std::string specialCellTypeName(const SpecialCellType c);
 }

--- a/src/types/Exceptions.h
+++ b/src/types/Exceptions.h
@@ -68,4 +68,23 @@ namespace spelunker::types {
                    + ", so cannot perform symmetry: " + typeclasses::Show<types::Symmetry>::show(s);
         }
     };
+
+    /// Thrown if the user tries to specify a start or goal cell that is not legally placed.
+    /**
+     * Thrown if the user tries to specify a start or goal cell that is not legally placed.
+     * Note that this is reserved strictly for cells that is <b>in bounds.</b>
+     * Cells that are <b>out of bounds</b> are reported by @see{OutOfBoundsCoordinates}.
+     */
+     class IllegalCellPosition : public Exception {
+     public:
+         IllegalCellPosition(const types::Cell &c, const types::SpecialCellType ct) : Exception{msg(c, ct)} {}
+         IllegalCellPosition(const int x, const int y, const types::SpecialCellType ct)
+            : IllegalCellPosition{types::cell(x, y), ct} {}
+
+     private:
+         static std::string msg(const types::Cell &c, const types::SpecialCellType ct) {
+             return "The cell " + typeclasses::Show<types::Cell>::show(c) + " is not a legal " +
+                     types::specialCellTypeName(ct) + " cell.";
+         }
+     };
 }

--- a/src/types/ReversibleMaze.h
+++ b/src/types/ReversibleMaze.h
@@ -1,0 +1,29 @@
+/**
+ * ReversibleMaze.h
+ *
+ * By Sebastian Raaphorst, 2018.
+ *
+ * Represents a maze type that can reverse itself in some form.
+ * Reversing should be an operation of order 2.
+ */
+
+#pragma one
+
+namespace spelunker::types {
+    /**
+     * A maze type that has some concept of being reversible.
+     * Reversibility must be an operation of order precisely 2, i.e. a reversed
+     * maze must not be equivalent to its original form, but the reverse of a
+     * reversible maze must be equivalent to the starting form, with one exception:
+     *
+     * A newly reversible maze should not have a start cell or goal cells, since they
+     * would be reversed into non-cells; thus a doubly reversed maze will continue tp
+     * have its start and goal cells eliminated.
+     * @tparam T the type of maze
+     */
+    template<typename T>
+    class ReversibleMaze {
+    public:
+        virtual const T reverse() const noexcept = 0;
+    };
+}


### PR DESCRIPTION
This PR accomplishes the following:

1. Adds a new class, `ReversibleMaze`, to identify mazes that can be reversed.
2. Makes `ThickMaze` a `ReversibleMaze`.
3. Adds an exception, `IllegalCellPosition`, to be thrown if a special cell (start or goal) is in bounds but not assigned to a legal cell (e.g. is on a wall).
4. Adds a class enum, `SpecialMazeType` to represent the types of start and goal cells, and a function to translate them into string names.
5. Added test case for `ThickMaze` to make sure it obeys reversibility rules.