### PR TITLE
T119: Fixed problem with RNG and added braiding test cases.

### DIFF
--- a/src/math/RNG.h
+++ b/src/math/RNG.h
@@ -77,7 +77,8 @@ namespace spelunker::math {
         static void shuffle(Container &c) {
             auto r = getRNG();
 
-            const auto maxPos = c.size() - 1;
+            // c.size is unsigned, so we must cast to int for the case that it is 0.
+            const auto maxPos = static_cast<int>(c.size()) - 1;
             for (auto i=0; i < maxPos; ++i) {
                 // Find a random element and swap it with begin.
                 const auto idx = randomRange(i, c.size());

--- a/src/test/maze/CMakeLists.txt
+++ b/src/test/maze/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(maze_tests
         TestMaze
+        TestMazeBraiding
         TestMazeSymmetries
         TestRankPosition
         TestUnrankWallMap

--- a/src/test/maze/TestMazeBraiding.cpp
+++ b/src/test/maze/TestMazeBraiding.cpp
@@ -1,0 +1,25 @@
+/**
+ * TestMazeBraiding.cpp
+ *
+ * By Sebastian Raaphorst, 2018.
+ */
+
+#include <catch.hpp>
+
+#include <maze/DFSMazeGenerator.h>
+#include <maze/Maze.h>
+
+using namespace spelunker;
+
+TEST_CASE("Maze should be able to serialize and deserialize", "[maze][braiding]") {
+    constexpr auto width = 50;
+    constexpr auto height = 40;
+    const maze::DFSMazeGenerator dfs{width, height};
+
+    const maze::Maze m  = dfs.generate();
+    const maze::Maze mb = m.braidAll();
+    REQUIRE(m != mb);
+
+    const maze::Maze mb2 = mb.braidAll();
+    REQUIRE(mb == mb2);
+}

--- a/src/test/thickmaze/CMakeLists.txt
+++ b/src/test/thickmaze/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(thickmaze_tests
         TestThickMaze
+        TestThickMazeBraiding
         TestThickMazeSymmetries
         PARENT_SCOPE
         )

--- a/src/test/thickmaze/TestThickMazeBraiding.cpp
+++ b/src/test/thickmaze/TestThickMazeBraiding.cpp
@@ -1,0 +1,24 @@
+
+#include <catch.hpp>
+
+#include <types/CommonMazeAttributes.h>
+#include <types/Dimensions2D.h>
+#include <maze/DFSMazeGenerator.h>
+#include <thickmaze/ThickMaze.h>
+#include <thickmaze/ThickMazeGeneratorByHomomorphism.h>
+
+using namespace spelunker;
+
+TEST_CASE("ThickMaze should be able to serialize and deserialize", "[thickmaze][serialization]") {
+    constexpr auto width = 25;
+    constexpr auto height = 20;
+    const types::Dimensions2D dim{width, height};
+    thickmaze::ThickMazeGeneratorByHomomorphism dfs{maze::DFSMazeGenerator{dim}};
+
+    const thickmaze::ThickMaze tm  = dfs.generate();
+    const thickmaze::ThickMaze tmb = tm.braidAll();
+    REQUIRE(tm != tmb);
+
+    const thickmaze::ThickMaze tmb2 = tmb.braidAll();
+    REQUIRE(tmb == tmb2);
+}


### PR DESCRIPTION
The `RNG::shuffle` method was broken, as I used `c.size() - 1`. Since `c.size` is of an unsigned type, this caused an underflow that was detected when an exception was thrown when braiding mazes with no dead ends.

This has now been fixed, and test cases for braiding have been added.